### PR TITLE
chore: optimize sort/filter with gqlgen model binding and IntID scalar

### DIFF
--- a/perspectize-go/gqlgen.yml
+++ b/perspectize-go/gqlgen.yml
@@ -34,3 +34,30 @@ models:
   JSON:
     model:
       - github.com/99designs/gqlgen/graphql.Map
+
+  # Custom scalar for ID conversion
+  IntID:
+    model:
+      - github.com/yourorg/perspectize-go/pkg/graphql.IntID
+
+  # Sort enums - bind directly to domain types
+  SortOrder:
+    model:
+      - github.com/yourorg/perspectize-go/internal/core/domain.SortOrder
+  ContentSortBy:
+    model:
+      - github.com/yourorg/perspectize-go/internal/core/domain.ContentSortBy
+  PerspectiveSortBy:
+    model:
+      - github.com/yourorg/perspectize-go/internal/core/domain.PerspectiveSortBy
+
+  # Stored enums - bind directly to domain types
+  Privacy:
+    model:
+      - github.com/yourorg/perspectize-go/internal/core/domain.Privacy
+  ContentType:
+    model:
+      - github.com/yourorg/perspectize-go/internal/core/domain.ContentType
+  ReviewStatus:
+    model:
+      - github.com/yourorg/perspectize-go/internal/core/domain.ReviewStatus

--- a/perspectize-go/internal/adapters/graphql/generated/generated.go
+++ b/perspectize-go/internal/adapters/graphql/generated/generated.go
@@ -16,6 +16,8 @@ import (
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/yourorg/perspectize-go/internal/adapters/graphql/model"
+	"github.com/yourorg/perspectize-go/internal/core/domain"
+	graphql1 "github.com/yourorg/perspectize-go/pkg/graphql"
 )
 
 // region    ************************** generated!.gotpl **************************
@@ -117,10 +119,10 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Content         func(childComplexity int, first *int, after *string, last *int, before *string, sortBy *model.ContentSortBy, sortOrder *model.SortOrder, includeTotalCount *bool, filter *model.ContentFilter) int
+		Content         func(childComplexity int, first *int, after *string, last *int, before *string, sortBy *domain.ContentSortBy, sortOrder *domain.SortOrder, includeTotalCount *bool, filter *model.ContentFilter) int
 		ContentByID     func(childComplexity int, id string) int
 		PerspectiveByID func(childComplexity int, id string) int
-		Perspectives    func(childComplexity int, first *int, after *string, last *int, before *string, sortBy *model.PerspectiveSortBy, sortOrder *model.SortOrder, includeTotalCount *bool, filter *model.PerspectiveFilter) int
+		Perspectives    func(childComplexity int, first *int, after *string, last *int, before *string, sortBy *domain.PerspectiveSortBy, sortOrder *domain.SortOrder, includeTotalCount *bool, filter *model.PerspectiveFilter) int
 		UserByID        func(childComplexity int, id string) int
 		UserByUsername  func(childComplexity int, username string) int
 	}
@@ -143,11 +145,11 @@ type MutationResolver interface {
 }
 type QueryResolver interface {
 	ContentByID(ctx context.Context, id string) (*model.Content, error)
-	Content(ctx context.Context, first *int, after *string, last *int, before *string, sortBy *model.ContentSortBy, sortOrder *model.SortOrder, includeTotalCount *bool, filter *model.ContentFilter) (*model.PaginatedContent, error)
+	Content(ctx context.Context, first *int, after *string, last *int, before *string, sortBy *domain.ContentSortBy, sortOrder *domain.SortOrder, includeTotalCount *bool, filter *model.ContentFilter) (*model.PaginatedContent, error)
 	UserByID(ctx context.Context, id string) (*model.User, error)
 	UserByUsername(ctx context.Context, username string) (*model.User, error)
 	PerspectiveByID(ctx context.Context, id string) (*model.Perspective, error)
-	Perspectives(ctx context.Context, first *int, after *string, last *int, before *string, sortBy *model.PerspectiveSortBy, sortOrder *model.SortOrder, includeTotalCount *bool, filter *model.PerspectiveFilter) (*model.PaginatedPerspectives, error)
+	Perspectives(ctx context.Context, first *int, after *string, last *int, before *string, sortBy *domain.PerspectiveSortBy, sortOrder *domain.SortOrder, includeTotalCount *bool, filter *model.PerspectiveFilter) (*model.PaginatedPerspectives, error)
 }
 
 type executableSchema struct {
@@ -505,7 +507,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Content(childComplexity, args["first"].(*int), args["after"].(*string), args["last"].(*int), args["before"].(*string), args["sortBy"].(*model.ContentSortBy), args["sortOrder"].(*model.SortOrder), args["includeTotalCount"].(*bool), args["filter"].(*model.ContentFilter)), true
+		return e.complexity.Query.Content(childComplexity, args["first"].(*int), args["after"].(*string), args["last"].(*int), args["before"].(*string), args["sortBy"].(*domain.ContentSortBy), args["sortOrder"].(*domain.SortOrder), args["includeTotalCount"].(*bool), args["filter"].(*model.ContentFilter)), true
 	case "Query.contentByID":
 		if e.complexity.Query.ContentByID == nil {
 			break
@@ -538,7 +540,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Perspectives(childComplexity, args["first"].(*int), args["after"].(*string), args["last"].(*int), args["before"].(*string), args["sortBy"].(*model.PerspectiveSortBy), args["sortOrder"].(*model.SortOrder), args["includeTotalCount"].(*bool), args["filter"].(*model.PerspectiveFilter)), true
+		return e.complexity.Query.Perspectives(childComplexity, args["first"].(*int), args["after"].(*string), args["last"].(*int), args["before"].(*string), args["sortBy"].(*domain.PerspectiveSortBy), args["sortOrder"].(*domain.SortOrder), args["includeTotalCount"].(*bool), args["filter"].(*model.PerspectiveFilter)), true
 	case "Query.userByID":
 		if e.complexity.Query.UserByID == nil {
 			break
@@ -706,6 +708,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 
 var sources = []*ast.Source{
 	{Name: "../../../../schema.graphql", Input: `scalar JSON
+scalar IntID
 
 # User type
 type User {
@@ -840,8 +843,8 @@ input CategorizedRatingInput {
 
 input CreatePerspectiveInput {
   claim: String!
-  userID: ID!
-  contentID: ID
+  userID: IntID!
+  contentID: IntID
   quality: Int
   agreement: Int
   importance: Int
@@ -856,9 +859,9 @@ input CreatePerspectiveInput {
 }
 
 input UpdatePerspectiveInput {
-  id: ID!
+  id: IntID!
   claim: String
-  contentID: ID
+  contentID: IntID
   quality: Int
   agreement: Int
   importance: Int
@@ -874,8 +877,8 @@ input UpdatePerspectiveInput {
 }
 
 input PerspectiveFilter {
-  userID: ID
-  contentID: ID
+  userID: IntID
+  contentID: IntID
   privacy: Privacy
 }
 
@@ -1032,12 +1035,12 @@ func (ec *executionContext) field_Query_content_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["before"] = arg3
-	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "sortBy", ec.unmarshalOContentSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐContentSortBy)
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "sortBy", ec.unmarshalOContentSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐContentSortBy)
 	if err != nil {
 		return nil, err
 	}
 	args["sortBy"] = arg4
-	arg5, err := graphql.ProcessArgField(ctx, rawArgs, "sortOrder", ec.unmarshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐSortOrder)
+	arg5, err := graphql.ProcessArgField(ctx, rawArgs, "sortOrder", ec.unmarshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐSortOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -1089,12 +1092,12 @@ func (ec *executionContext) field_Query_perspectives_args(ctx context.Context, r
 		return nil, err
 	}
 	args["before"] = arg3
-	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "sortBy", ec.unmarshalOPerspectiveSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPerspectiveSortBy)
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "sortBy", ec.unmarshalOPerspectiveSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPerspectiveSortBy)
 	if err != nil {
 		return nil, err
 	}
 	args["sortBy"] = arg4
-	arg5, err := graphql.ProcessArgField(ctx, rawArgs, "sortOrder", ec.unmarshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐSortOrder)
+	arg5, err := graphql.ProcessArgField(ctx, rawArgs, "sortOrder", ec.unmarshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐSortOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -2664,7 +2667,7 @@ func (ec *executionContext) _Perspective_privacy(ctx context.Context, field grap
 			return obj.Privacy, nil
 		},
 		nil,
-		ec.marshalNPrivacy2githubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy,
+		ec.marshalNPrivacy2githubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy,
 		true,
 		true,
 	)
@@ -2751,7 +2754,7 @@ func (ec *executionContext) _Perspective_reviewStatus(ctx context.Context, field
 			return obj.ReviewStatus, nil
 		},
 		nil,
-		ec.marshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐReviewStatus,
+		ec.marshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐReviewStatus,
 		true,
 		false,
 	)
@@ -2996,7 +2999,7 @@ func (ec *executionContext) _Query_content(ctx context.Context, field graphql.Co
 		ec.fieldContext_Query_content,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Content(ctx, fc.Args["first"].(*int), fc.Args["after"].(*string), fc.Args["last"].(*int), fc.Args["before"].(*string), fc.Args["sortBy"].(*model.ContentSortBy), fc.Args["sortOrder"].(*model.SortOrder), fc.Args["includeTotalCount"].(*bool), fc.Args["filter"].(*model.ContentFilter))
+			return ec.resolvers.Query().Content(ctx, fc.Args["first"].(*int), fc.Args["after"].(*string), fc.Args["last"].(*int), fc.Args["before"].(*string), fc.Args["sortBy"].(*domain.ContentSortBy), fc.Args["sortOrder"].(*domain.SortOrder), fc.Args["includeTotalCount"].(*bool), fc.Args["filter"].(*model.ContentFilter))
 		},
 		nil,
 		ec.marshalNPaginatedContent2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPaginatedContent,
@@ -3234,7 +3237,7 @@ func (ec *executionContext) _Query_perspectives(ctx context.Context, field graph
 		ec.fieldContext_Query_perspectives,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Query().Perspectives(ctx, fc.Args["first"].(*int), fc.Args["after"].(*string), fc.Args["last"].(*int), fc.Args["before"].(*string), fc.Args["sortBy"].(*model.PerspectiveSortBy), fc.Args["sortOrder"].(*model.SortOrder), fc.Args["includeTotalCount"].(*bool), fc.Args["filter"].(*model.PerspectiveFilter))
+			return ec.resolvers.Query().Perspectives(ctx, fc.Args["first"].(*int), fc.Args["after"].(*string), fc.Args["last"].(*int), fc.Args["before"].(*string), fc.Args["sortBy"].(*domain.PerspectiveSortBy), fc.Args["sortOrder"].(*domain.SortOrder), fc.Args["includeTotalCount"].(*bool), fc.Args["filter"].(*model.PerspectiveFilter))
 		},
 		nil,
 		ec.marshalNPaginatedPerspectives2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPaginatedPerspectives,
@@ -5024,7 +5027,7 @@ func (ec *executionContext) unmarshalInputContentFilter(ctx context.Context, obj
 		switch k {
 		case "contentType":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contentType"))
-			data, err := ec.unmarshalOContentType2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐContentType(ctx, v)
+			data, err := ec.unmarshalOContentType2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐContentType(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5099,14 +5102,14 @@ func (ec *executionContext) unmarshalInputCreatePerspectiveInput(ctx context.Con
 			it.Claim = data
 		case "userID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userID"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalNIntID2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.UserID = data
 		case "contentID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contentID"))
-			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			data, err := ec.unmarshalOIntID2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5148,7 +5151,7 @@ func (ec *executionContext) unmarshalInputCreatePerspectiveInput(ctx context.Con
 			it.Like = data
 		case "privacy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("privacy"))
-			data, err := ec.unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx, v)
+			data, err := ec.unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5244,21 +5247,21 @@ func (ec *executionContext) unmarshalInputPerspectiveFilter(ctx context.Context,
 		switch k {
 		case "userID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userID"))
-			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			data, err := ec.unmarshalOIntID2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.UserID = data
 		case "contentID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contentID"))
-			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			data, err := ec.unmarshalOIntID2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
 			it.ContentID = data
 		case "privacy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("privacy"))
-			data, err := ec.unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx, v)
+			data, err := ec.unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5285,7 +5288,7 @@ func (ec *executionContext) unmarshalInputUpdatePerspectiveInput(ctx context.Con
 		switch k {
 		case "id":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalNIntID2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5299,7 +5302,7 @@ func (ec *executionContext) unmarshalInputUpdatePerspectiveInput(ctx context.Con
 			it.Claim = data
 		case "contentID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contentID"))
-			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			data, err := ec.unmarshalOIntID2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5341,7 +5344,7 @@ func (ec *executionContext) unmarshalInputUpdatePerspectiveInput(ctx context.Con
 			it.Like = data
 		case "privacy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("privacy"))
-			data, err := ec.unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx, v)
+			data, err := ec.unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5362,7 +5365,7 @@ func (ec *executionContext) unmarshalInputUpdatePerspectiveInput(ctx context.Con
 			it.Category = data
 		case "reviewStatus":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("reviewStatus"))
-			data, err := ec.unmarshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐReviewStatus(ctx, v)
+			data, err := ec.unmarshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐReviewStatus(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6528,6 +6531,22 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
+func (ec *executionContext) unmarshalNIntID2int(ctx context.Context, v any) (int, error) {
+	res, err := graphql1.UnmarshalIntID(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNIntID2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	_ = sel
+	res := graphql1.MarshalIntID(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) marshalNPageInfo2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPageInfo(ctx context.Context, sel ast.SelectionSet, v *model.PageInfo) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6624,14 +6643,21 @@ func (ec *executionContext) marshalNPerspective2ᚖgithubᚗcomᚋyourorgᚋpers
 	return ec._Perspective(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNPrivacy2githubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx context.Context, v any) (model.Privacy, error) {
-	var res model.Privacy
-	err := res.UnmarshalGQL(v)
+func (ec *executionContext) unmarshalNPrivacy2githubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx context.Context, v any) (domain.Privacy, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.Privacy(tmp)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNPrivacy2githubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx context.Context, sel ast.SelectionSet, v model.Privacy) graphql.Marshaler {
-	return v
+func (ec *executionContext) marshalNPrivacy2githubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx context.Context, sel ast.SelectionSet, v domain.Privacy) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {
@@ -7032,36 +7058,42 @@ func (ec *executionContext) unmarshalOContentFilter2ᚖgithubᚗcomᚋyourorgᚋ
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOContentSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐContentSortBy(ctx context.Context, v any) (*model.ContentSortBy, error) {
+func (ec *executionContext) unmarshalOContentSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐContentSortBy(ctx context.Context, v any) (*domain.ContentSortBy, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(model.ContentSortBy)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.ContentSortBy(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOContentSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐContentSortBy(ctx context.Context, sel ast.SelectionSet, v *model.ContentSortBy) graphql.Marshaler {
+func (ec *executionContext) marshalOContentSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐContentSortBy(ctx context.Context, sel ast.SelectionSet, v *domain.ContentSortBy) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
-func (ec *executionContext) unmarshalOContentType2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐContentType(ctx context.Context, v any) (*model.ContentType, error) {
+func (ec *executionContext) unmarshalOContentType2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐContentType(ctx context.Context, v any) (*domain.ContentType, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(model.ContentType)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.ContentType(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOContentType2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐContentType(ctx context.Context, sel ast.SelectionSet, v *model.ContentType) graphql.Marshaler {
+func (ec *executionContext) marshalOContentType2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐContentType(ctx context.Context, sel ast.SelectionSet, v *domain.ContentType) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
 func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v any) (*string, error) {
@@ -7136,6 +7168,24 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 	return res
 }
 
+func (ec *executionContext) unmarshalOIntID2ᚖint(ctx context.Context, v any) (*int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql1.UnmarshalIntID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOIntID2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql1.MarshalIntID(*v)
+	return res
+}
+
 func (ec *executionContext) unmarshalOJSON2map(ctx context.Context, v any) (map[string]any, error) {
 	if v == nil {
 		return nil, nil
@@ -7169,68 +7219,80 @@ func (ec *executionContext) unmarshalOPerspectiveFilter2ᚖgithubᚗcomᚋyouror
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOPerspectiveSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPerspectiveSortBy(ctx context.Context, v any) (*model.PerspectiveSortBy, error) {
+func (ec *executionContext) unmarshalOPerspectiveSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPerspectiveSortBy(ctx context.Context, v any) (*domain.PerspectiveSortBy, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(model.PerspectiveSortBy)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.PerspectiveSortBy(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOPerspectiveSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPerspectiveSortBy(ctx context.Context, sel ast.SelectionSet, v *model.PerspectiveSortBy) graphql.Marshaler {
+func (ec *executionContext) marshalOPerspectiveSortBy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPerspectiveSortBy(ctx context.Context, sel ast.SelectionSet, v *domain.PerspectiveSortBy) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
-func (ec *executionContext) unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx context.Context, v any) (*model.Privacy, error) {
+func (ec *executionContext) unmarshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx context.Context, v any) (*domain.Privacy, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(model.Privacy)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.Privacy(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐPrivacy(ctx context.Context, sel ast.SelectionSet, v *model.Privacy) graphql.Marshaler {
+func (ec *executionContext) marshalOPrivacy2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐPrivacy(ctx context.Context, sel ast.SelectionSet, v *domain.Privacy) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
-func (ec *executionContext) unmarshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐReviewStatus(ctx context.Context, v any) (*model.ReviewStatus, error) {
+func (ec *executionContext) unmarshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐReviewStatus(ctx context.Context, v any) (*domain.ReviewStatus, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(model.ReviewStatus)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.ReviewStatus(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐReviewStatus(ctx context.Context, sel ast.SelectionSet, v *model.ReviewStatus) graphql.Marshaler {
+func (ec *executionContext) marshalOReviewStatus2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐReviewStatus(ctx context.Context, sel ast.SelectionSet, v *domain.ReviewStatus) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
-func (ec *executionContext) unmarshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐSortOrder(ctx context.Context, v any) (*model.SortOrder, error) {
+func (ec *executionContext) unmarshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐSortOrder(ctx context.Context, v any) (*domain.SortOrder, error) {
 	if v == nil {
 		return nil, nil
 	}
-	var res = new(model.SortOrder)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+	tmp, err := graphql.UnmarshalString(v)
+	res := domain.SortOrder(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋadaptersᚋgraphqlᚋmodelᚐSortOrder(ctx context.Context, sel ast.SelectionSet, v *model.SortOrder) graphql.Marshaler {
+func (ec *executionContext) marshalOSortOrder2ᚖgithubᚗcomᚋyourorgᚋperspectizeᚑgoᚋinternalᚋcoreᚋdomainᚐSortOrder(ctx context.Context, sel ast.SelectionSet, v *domain.SortOrder) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	return v
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
 func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {

--- a/perspectize-go/internal/adapters/graphql/model/models_gen.go
+++ b/perspectize-go/internal/adapters/graphql/model/models_gen.go
@@ -3,10 +3,7 @@
 package model
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"strconv"
+	"github.com/yourorg/perspectize-go/internal/core/domain"
 )
 
 type CategorizedRating struct {
@@ -35,9 +32,9 @@ type Content struct {
 }
 
 type ContentFilter struct {
-	ContentType      *ContentType `json:"contentType,omitempty"`
-	MinLengthSeconds *int         `json:"minLengthSeconds,omitempty"`
-	MaxLengthSeconds *int         `json:"maxLengthSeconds,omitempty"`
+	ContentType      *domain.ContentType `json:"contentType,omitempty"`
+	MinLengthSeconds *int                `json:"minLengthSeconds,omitempty"`
+	MaxLengthSeconds *int                `json:"maxLengthSeconds,omitempty"`
 }
 
 type CreateContentFromYouTubeInput struct {
@@ -46,14 +43,14 @@ type CreateContentFromYouTubeInput struct {
 
 type CreatePerspectiveInput struct {
 	Claim              string                    `json:"claim"`
-	UserID             string                    `json:"userID"`
-	ContentID          *string                   `json:"contentID,omitempty"`
+	UserID             int                       `json:"userID"`
+	ContentID          *int                      `json:"contentID,omitempty"`
 	Quality            *int                      `json:"quality,omitempty"`
 	Agreement          *int                      `json:"agreement,omitempty"`
 	Importance         *int                      `json:"importance,omitempty"`
 	Confidence         *int                      `json:"confidence,omitempty"`
 	Like               *string                   `json:"like,omitempty"`
-	Privacy            *Privacy                  `json:"privacy,omitempty"`
+	Privacy            *domain.Privacy           `json:"privacy,omitempty"`
 	Description        *string                   `json:"description,omitempty"`
 	Category           *string                   `json:"category,omitempty"`
 	Parts              []int                     `json:"parts,omitempty"`
@@ -100,10 +97,10 @@ type Perspective struct {
 	Importance         *int                 `json:"importance,omitempty"`
 	Confidence         *int                 `json:"confidence,omitempty"`
 	Like               *string              `json:"like,omitempty"`
-	Privacy            Privacy              `json:"privacy"`
+	Privacy            domain.Privacy       `json:"privacy"`
 	Description        *string              `json:"description,omitempty"`
 	Category           *string              `json:"category,omitempty"`
-	ReviewStatus       *ReviewStatus        `json:"reviewStatus,omitempty"`
+	ReviewStatus       *domain.ReviewStatus `json:"reviewStatus,omitempty"`
 	Parts              []int                `json:"parts,omitempty"`
 	Labels             []string             `json:"labels,omitempty"`
 	CategorizedRatings []*CategorizedRating `json:"categorizedRatings,omitempty"`
@@ -112,27 +109,27 @@ type Perspective struct {
 }
 
 type PerspectiveFilter struct {
-	UserID    *string  `json:"userID,omitempty"`
-	ContentID *string  `json:"contentID,omitempty"`
-	Privacy   *Privacy `json:"privacy,omitempty"`
+	UserID    *int            `json:"userID,omitempty"`
+	ContentID *int            `json:"contentID,omitempty"`
+	Privacy   *domain.Privacy `json:"privacy,omitempty"`
 }
 
 type Query struct {
 }
 
 type UpdatePerspectiveInput struct {
-	ID                 string                    `json:"id"`
+	ID                 int                       `json:"id"`
 	Claim              *string                   `json:"claim,omitempty"`
-	ContentID          *string                   `json:"contentID,omitempty"`
+	ContentID          *int                      `json:"contentID,omitempty"`
 	Quality            *int                      `json:"quality,omitempty"`
 	Agreement          *int                      `json:"agreement,omitempty"`
 	Importance         *int                      `json:"importance,omitempty"`
 	Confidence         *int                      `json:"confidence,omitempty"`
 	Like               *string                   `json:"like,omitempty"`
-	Privacy            *Privacy                  `json:"privacy,omitempty"`
+	Privacy            *domain.Privacy           `json:"privacy,omitempty"`
 	Description        *string                   `json:"description,omitempty"`
 	Category           *string                   `json:"category,omitempty"`
-	ReviewStatus       *ReviewStatus             `json:"reviewStatus,omitempty"`
+	ReviewStatus       *domain.ReviewStatus      `json:"reviewStatus,omitempty"`
 	Parts              []int                     `json:"parts,omitempty"`
 	Labels             []string                  `json:"labels,omitempty"`
 	CategorizedRatings []*CategorizedRatingInput `json:"categorizedRatings,omitempty"`
@@ -144,338 +141,4 @@ type User struct {
 	Email     string `json:"email"`
 	CreatedAt string `json:"createdAt"`
 	UpdatedAt string `json:"updatedAt"`
-}
-
-type ContentSortBy string
-
-const (
-	ContentSortByCreatedAt ContentSortBy = "CREATED_AT"
-	ContentSortByUpdatedAt ContentSortBy = "UPDATED_AT"
-	ContentSortByName      ContentSortBy = "NAME"
-)
-
-var AllContentSortBy = []ContentSortBy{
-	ContentSortByCreatedAt,
-	ContentSortByUpdatedAt,
-	ContentSortByName,
-}
-
-func (e ContentSortBy) IsValid() bool {
-	switch e {
-	case ContentSortByCreatedAt, ContentSortByUpdatedAt, ContentSortByName:
-		return true
-	}
-	return false
-}
-
-func (e ContentSortBy) String() string {
-	return string(e)
-}
-
-func (e *ContentSortBy) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = ContentSortBy(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid ContentSortBy", str)
-	}
-	return nil
-}
-
-func (e ContentSortBy) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *ContentSortBy) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e ContentSortBy) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
-}
-
-type ContentType string
-
-const (
-	ContentTypeYoutube ContentType = "YOUTUBE"
-)
-
-var AllContentType = []ContentType{
-	ContentTypeYoutube,
-}
-
-func (e ContentType) IsValid() bool {
-	switch e {
-	case ContentTypeYoutube:
-		return true
-	}
-	return false
-}
-
-func (e ContentType) String() string {
-	return string(e)
-}
-
-func (e *ContentType) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = ContentType(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid ContentType", str)
-	}
-	return nil
-}
-
-func (e ContentType) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *ContentType) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e ContentType) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
-}
-
-type PerspectiveSortBy string
-
-const (
-	PerspectiveSortByCreatedAt PerspectiveSortBy = "CREATED_AT"
-	PerspectiveSortByUpdatedAt PerspectiveSortBy = "UPDATED_AT"
-	PerspectiveSortByClaim     PerspectiveSortBy = "CLAIM"
-)
-
-var AllPerspectiveSortBy = []PerspectiveSortBy{
-	PerspectiveSortByCreatedAt,
-	PerspectiveSortByUpdatedAt,
-	PerspectiveSortByClaim,
-}
-
-func (e PerspectiveSortBy) IsValid() bool {
-	switch e {
-	case PerspectiveSortByCreatedAt, PerspectiveSortByUpdatedAt, PerspectiveSortByClaim:
-		return true
-	}
-	return false
-}
-
-func (e PerspectiveSortBy) String() string {
-	return string(e)
-}
-
-func (e *PerspectiveSortBy) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = PerspectiveSortBy(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid PerspectiveSortBy", str)
-	}
-	return nil
-}
-
-func (e PerspectiveSortBy) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *PerspectiveSortBy) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e PerspectiveSortBy) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
-}
-
-type Privacy string
-
-const (
-	PrivacyPublic  Privacy = "PUBLIC"
-	PrivacyPrivate Privacy = "PRIVATE"
-)
-
-var AllPrivacy = []Privacy{
-	PrivacyPublic,
-	PrivacyPrivate,
-}
-
-func (e Privacy) IsValid() bool {
-	switch e {
-	case PrivacyPublic, PrivacyPrivate:
-		return true
-	}
-	return false
-}
-
-func (e Privacy) String() string {
-	return string(e)
-}
-
-func (e *Privacy) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = Privacy(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid Privacy", str)
-	}
-	return nil
-}
-
-func (e Privacy) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *Privacy) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e Privacy) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
-}
-
-type ReviewStatus string
-
-const (
-	ReviewStatusPending  ReviewStatus = "PENDING"
-	ReviewStatusApproved ReviewStatus = "APPROVED"
-	ReviewStatusRejected ReviewStatus = "REJECTED"
-)
-
-var AllReviewStatus = []ReviewStatus{
-	ReviewStatusPending,
-	ReviewStatusApproved,
-	ReviewStatusRejected,
-}
-
-func (e ReviewStatus) IsValid() bool {
-	switch e {
-	case ReviewStatusPending, ReviewStatusApproved, ReviewStatusRejected:
-		return true
-	}
-	return false
-}
-
-func (e ReviewStatus) String() string {
-	return string(e)
-}
-
-func (e *ReviewStatus) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = ReviewStatus(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid ReviewStatus", str)
-	}
-	return nil
-}
-
-func (e ReviewStatus) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *ReviewStatus) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e ReviewStatus) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
-}
-
-type SortOrder string
-
-const (
-	SortOrderAsc  SortOrder = "ASC"
-	SortOrderDesc SortOrder = "DESC"
-)
-
-var AllSortOrder = []SortOrder{
-	SortOrderAsc,
-	SortOrderDesc,
-}
-
-func (e SortOrder) IsValid() bool {
-	switch e {
-	case SortOrderAsc, SortOrderDesc:
-		return true
-	}
-	return false
-}
-
-func (e SortOrder) String() string {
-	return string(e)
-}
-
-func (e *SortOrder) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = SortOrder(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid SortOrder", str)
-	}
-	return nil
-}
-
-func (e SortOrder) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *SortOrder) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e SortOrder) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
 }

--- a/perspectize-go/internal/adapters/graphql/resolvers/helpers.go
+++ b/perspectize-go/internal/adapters/graphql/resolvers/helpers.go
@@ -69,31 +69,27 @@ func domainToModel(c *domain.Content) *model.Content {
 // perspectiveDomainToModel converts a domain Perspective to a GraphQL model Perspective
 func perspectiveDomainToModel(p *domain.Perspective) *model.Perspective {
 	m := &model.Perspective{
-		ID:          strconv.Itoa(p.ID),
-		Claim:       p.Claim,
-		UserID:      strconv.Itoa(p.UserID),
-		Quality:     p.Quality,
-		Agreement:   p.Agreement,
-		Importance:  p.Importance,
-		Confidence:  p.Confidence,
-		Like:        p.Like,
-		Privacy:     privacyDomainToModel(p.Privacy),
-		Description: p.Description,
-		Category:    p.Category,
-		Parts:       p.Parts,
-		Labels:      p.Labels,
-		CreatedAt:   p.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:   p.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		ID:           strconv.Itoa(p.ID),
+		Claim:        p.Claim,
+		UserID:       strconv.Itoa(p.UserID),
+		Quality:      p.Quality,
+		Agreement:    p.Agreement,
+		Importance:   p.Importance,
+		Confidence:   p.Confidence,
+		Like:         p.Like,
+		Privacy:      p.Privacy,
+		Description:  p.Description,
+		Category:     p.Category,
+		Parts:        p.Parts,
+		Labels:       p.Labels,
+		ReviewStatus: p.ReviewStatus,
+		CreatedAt:    p.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:    p.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 
 	if p.ContentID != nil {
 		contentID := strconv.Itoa(*p.ContentID)
 		m.ContentID = &contentID
-	}
-
-	if p.ReviewStatus != nil {
-		status := reviewStatusDomainToModel(*p.ReviewStatus)
-		m.ReviewStatus = &status
 	}
 
 	// Convert categorized ratings
@@ -108,58 +104,4 @@ func perspectiveDomainToModel(p *domain.Perspective) *model.Perspective {
 	}
 
 	return m
-}
-
-// privacyDomainToModel converts domain Privacy to GraphQL model Privacy
-func privacyDomainToModel(p domain.Privacy) model.Privacy {
-	switch p {
-	case domain.PrivacyPrivate:
-		return model.PrivacyPrivate
-	default:
-		return model.PrivacyPublic
-	}
-}
-
-// privacyModelToDomain converts GraphQL model Privacy to domain Privacy
-func privacyModelToDomain(p *model.Privacy) *domain.Privacy {
-	if p == nil {
-		return nil
-	}
-	var dp domain.Privacy
-	switch *p {
-	case model.PrivacyPrivate:
-		dp = domain.PrivacyPrivate
-	default:
-		dp = domain.PrivacyPublic
-	}
-	return &dp
-}
-
-// reviewStatusDomainToModel converts domain ReviewStatus to GraphQL model ReviewStatus
-func reviewStatusDomainToModel(s domain.ReviewStatus) model.ReviewStatus {
-	switch s {
-	case domain.ReviewStatusApproved:
-		return model.ReviewStatusApproved
-	case domain.ReviewStatusRejected:
-		return model.ReviewStatusRejected
-	default:
-		return model.ReviewStatusPending
-	}
-}
-
-// reviewStatusModelToDomain converts GraphQL model ReviewStatus to domain ReviewStatus
-func reviewStatusModelToDomain(s *model.ReviewStatus) *domain.ReviewStatus {
-	if s == nil {
-		return nil
-	}
-	var ds domain.ReviewStatus
-	switch *s {
-	case model.ReviewStatusApproved:
-		ds = domain.ReviewStatusApproved
-	case model.ReviewStatusRejected:
-		ds = domain.ReviewStatusRejected
-	default:
-		ds = domain.ReviewStatusPending
-	}
-	return &ds
 }

--- a/perspectize-go/internal/adapters/repositories/postgres/content_repository.go
+++ b/perspectize-go/internal/adapters/repositories/postgres/content_repository.go
@@ -49,7 +49,7 @@ func (r *ContentRepository) Create(ctx context.Context, content *domain.Content)
 	err := r.db.QueryRowContext(ctx, query,
 		content.Name,
 		toNullString(content.URL),
-		string(content.ContentType),
+		contentTypeToDBValue(content.ContentType),
 		toNullInt64(content.Length),
 		toNullString(content.LengthUnits),
 		content.Response,
@@ -109,7 +109,7 @@ func rowToDomain(row *contentRow) *domain.Content {
 	content := &domain.Content{
 		ID:          row.ID,
 		Name:        row.Name,
-		ContentType: domain.ContentType(row.ContentType),
+		ContentType: contentTypeFromDBValue(row.ContentType),
 		Response:    row.Response,
 	}
 
@@ -131,6 +131,16 @@ func rowToDomain(row *contentRow) *domain.Content {
 	}
 
 	return content
+}
+
+// contentTypeToDBValue converts domain ContentType to lowercase for database storage
+func contentTypeToDBValue(ct domain.ContentType) string {
+	return strings.ToLower(string(ct))
+}
+
+// contentTypeFromDBValue converts lowercase database value to domain ContentType
+func contentTypeFromDBValue(s string) domain.ContentType {
+	return domain.ContentType(strings.ToUpper(s))
 }
 
 // toNullString converts a string pointer to sql.NullString
@@ -178,6 +188,8 @@ func sortColumnName(sortBy domain.ContentSortBy) string {
 		return "updated_at"
 	case domain.ContentSortByName:
 		return "name"
+	case domain.ContentSortByCreatedAt:
+		return "created_at"
 	default:
 		return "created_at"
 	}
@@ -224,7 +236,7 @@ func (r *ContentRepository) List(ctx context.Context, params domain.ContentListP
 	if params.Filter != nil {
 		if params.Filter.ContentType != nil {
 			conditions = append(conditions, fmt.Sprintf("content_type = $%d", argIdx))
-			args = append(args, string(*params.Filter.ContentType))
+			args = append(args, contentTypeToDBValue(*params.Filter.ContentType))
 			argIdx++
 		}
 		if params.Filter.MinLengthSeconds != nil {
@@ -293,7 +305,7 @@ func (r *ContentRepository) List(ctx context.Context, params domain.ContentListP
 		if params.Filter != nil {
 			if params.Filter.ContentType != nil {
 				countConditions = append(countConditions, fmt.Sprintf("content_type = $%d", countArgIdx))
-				countArgs = append(countArgs, string(*params.Filter.ContentType))
+				countArgs = append(countArgs, contentTypeToDBValue(*params.Filter.ContentType))
 				countArgIdx++
 			}
 			if params.Filter.MinLengthSeconds != nil {

--- a/perspectize-go/internal/core/domain/content.go
+++ b/perspectize-go/internal/core/domain/content.go
@@ -9,7 +9,7 @@ import (
 type ContentType string
 
 const (
-	ContentTypeYouTube ContentType = "youtube"
+	ContentTypeYouTube ContentType = "YOUTUBE"
 )
 
 // Content represents a media item that users create perspectives on

--- a/perspectize-go/internal/core/domain/pagination.go
+++ b/perspectize-go/internal/core/domain/pagination.go
@@ -4,9 +4,9 @@ package domain
 type ContentSortBy string
 
 const (
-	ContentSortByCreatedAt ContentSortBy = "created_at"
-	ContentSortByUpdatedAt ContentSortBy = "updated_at"
-	ContentSortByName      ContentSortBy = "name"
+	ContentSortByCreatedAt ContentSortBy = "CREATED_AT"
+	ContentSortByUpdatedAt ContentSortBy = "UPDATED_AT"
+	ContentSortByName      ContentSortBy = "NAME"
 )
 
 // SortOrder represents ascending or descending sort direction

--- a/perspectize-go/internal/core/domain/perspective.go
+++ b/perspectize-go/internal/core/domain/perspective.go
@@ -9,17 +9,17 @@ import (
 type Privacy string
 
 const (
-	PrivacyPublic  Privacy = "public"
-	PrivacyPrivate Privacy = "private"
+	PrivacyPublic  Privacy = "PUBLIC"
+	PrivacyPrivate Privacy = "PRIVATE"
 )
 
 // ReviewStatus represents the review state of a perspective
 type ReviewStatus string
 
 const (
-	ReviewStatusPending  ReviewStatus = "pending"
-	ReviewStatusApproved ReviewStatus = "approved"
-	ReviewStatusRejected ReviewStatus = "rejected"
+	ReviewStatusPending  ReviewStatus = "PENDING"
+	ReviewStatusApproved ReviewStatus = "APPROVED"
+	ReviewStatusRejected ReviewStatus = "REJECTED"
 )
 
 // CategorizedRating represents a rating with a category label
@@ -78,9 +78,9 @@ func ValidateRating(rating *int) bool {
 type PerspectiveSortBy string
 
 const (
-	PerspectiveSortByCreatedAt PerspectiveSortBy = "created_at"
-	PerspectiveSortByUpdatedAt PerspectiveSortBy = "updated_at"
-	PerspectiveSortByClaim     PerspectiveSortBy = "claim"
+	PerspectiveSortByCreatedAt PerspectiveSortBy = "CREATED_AT"
+	PerspectiveSortByUpdatedAt PerspectiveSortBy = "UPDATED_AT"
+	PerspectiveSortByClaim     PerspectiveSortBy = "CLAIM"
 )
 
 // PerspectiveFilter contains filter criteria for perspective queries

--- a/perspectize-go/pkg/graphql/intid.go
+++ b/perspectize-go/pkg/graphql/intid.go
@@ -1,0 +1,35 @@
+package graphql
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+// IntID is a custom scalar that maps GraphQL ID (string) to Go int
+type IntID int
+
+// MarshalIntID marshals an int to a GraphQL ID string
+func MarshalIntID(id int) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		io.WriteString(w, strconv.Quote(strconv.Itoa(id)))
+	})
+}
+
+// UnmarshalIntID unmarshals a GraphQL ID to an int
+func UnmarshalIntID(v interface{}) (int, error) {
+	switch v := v.(type) {
+	case string:
+		return strconv.Atoi(v)
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	default:
+		return 0, fmt.Errorf("IntID must be a string or integer, got %T", v)
+	}
+}

--- a/perspectize-go/schema.graphql
+++ b/perspectize-go/schema.graphql
@@ -1,4 +1,5 @@
 scalar JSON
+scalar IntID
 
 # User type
 type User {
@@ -133,8 +134,8 @@ input CategorizedRatingInput {
 
 input CreatePerspectiveInput {
   claim: String!
-  userID: ID!
-  contentID: ID
+  userID: IntID!
+  contentID: IntID
   quality: Int
   agreement: Int
   importance: Int
@@ -149,9 +150,9 @@ input CreatePerspectiveInput {
 }
 
 input UpdatePerspectiveInput {
-  id: ID!
+  id: IntID!
   claim: String
-  contentID: ID
+  contentID: IntID
   quality: Int
   agreement: Int
   importance: Int
@@ -167,8 +168,8 @@ input UpdatePerspectiveInput {
 }
 
 input PerspectiveFilter {
-  userID: ID
-  contentID: ID
+  userID: IntID
+  contentID: IntID
   privacy: Privacy
 }
 

--- a/perspectize-go/test/domain/content_test.go
+++ b/perspectize-go/test/domain/content_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestContentType_YouTube(t *testing.T) {
-	assert.Equal(t, domain.ContentType("youtube"), domain.ContentTypeYouTube)
+	assert.Equal(t, domain.ContentType("YOUTUBE"), domain.ContentTypeYouTube)
 }
 
 func TestContent_RequiredFields(t *testing.T) {

--- a/perspectize-go/test/domain/perspective_test.go
+++ b/perspectize-go/test/domain/perspective_test.go
@@ -55,14 +55,14 @@ func TestPerspectiveZeroValue(t *testing.T) {
 }
 
 func TestPrivacyConstants(t *testing.T) {
-	assert.Equal(t, domain.Privacy("public"), domain.PrivacyPublic)
-	assert.Equal(t, domain.Privacy("private"), domain.PrivacyPrivate)
+	assert.Equal(t, domain.Privacy("PUBLIC"), domain.PrivacyPublic)
+	assert.Equal(t, domain.Privacy("PRIVATE"), domain.PrivacyPrivate)
 }
 
 func TestReviewStatusConstants(t *testing.T) {
-	assert.Equal(t, domain.ReviewStatus("pending"), domain.ReviewStatusPending)
-	assert.Equal(t, domain.ReviewStatus("approved"), domain.ReviewStatusApproved)
-	assert.Equal(t, domain.ReviewStatus("rejected"), domain.ReviewStatusRejected)
+	assert.Equal(t, domain.ReviewStatus("PENDING"), domain.ReviewStatusPending)
+	assert.Equal(t, domain.ReviewStatus("APPROVED"), domain.ReviewStatusApproved)
+	assert.Equal(t, domain.ReviewStatus("REJECTED"), domain.ReviewStatusRejected)
 }
 
 func TestRatingConstants(t *testing.T) {
@@ -81,9 +81,9 @@ func TestCategorizedRating(t *testing.T) {
 }
 
 func TestPerspectiveSortByConstants(t *testing.T) {
-	assert.Equal(t, domain.PerspectiveSortBy("created_at"), domain.PerspectiveSortByCreatedAt)
-	assert.Equal(t, domain.PerspectiveSortBy("updated_at"), domain.PerspectiveSortByUpdatedAt)
-	assert.Equal(t, domain.PerspectiveSortBy("claim"), domain.PerspectiveSortByClaim)
+	assert.Equal(t, domain.PerspectiveSortBy("CREATED_AT"), domain.PerspectiveSortByCreatedAt)
+	assert.Equal(t, domain.PerspectiveSortBy("UPDATED_AT"), domain.PerspectiveSortByUpdatedAt)
+	assert.Equal(t, domain.PerspectiveSortBy("CLAIM"), domain.PerspectiveSortByClaim)
 }
 
 func TestPerspectiveWithCategorizedRatings(t *testing.T) {

--- a/perspectize-go/test/resolvers/content_resolver_test.go
+++ b/perspectize-go/test/resolvers/content_resolver_test.go
@@ -233,7 +233,7 @@ func TestContentQuery_Success(t *testing.T) {
 
 	assert.Equal(t, "1", data.ContentByID.ID)
 	assert.Equal(t, "Test Video", data.ContentByID.Name)
-	assert.Equal(t, "youtube", data.ContentByID.ContentType)
+	assert.Equal(t, "YOUTUBE", data.ContentByID.ContentType)
 	assert.Equal(t, url, data.ContentByID.URL)
 }
 
@@ -352,7 +352,7 @@ func TestCreateContentFromYouTube_Success(t *testing.T) {
 
 	assert.Equal(t, "42", data.CreateContentFromYouTube.ID)
 	assert.Equal(t, "Amazing Video", data.CreateContentFromYouTube.Name)
-	assert.Equal(t, "youtube", data.CreateContentFromYouTube.ContentType)
+	assert.Equal(t, "YOUTUBE", data.CreateContentFromYouTube.ContentType)
 }
 
 func TestCreateContentFromYouTube_AlreadyExists(t *testing.T) {
@@ -670,7 +670,7 @@ func TestPaginatedContentQuery_WithContentTypeFilter(t *testing.T) {
 
 	assert.Len(t, data.Content.Items, 1)
 	assert.Equal(t, "YouTube Video", data.Content.Items[0].Name)
-	assert.Equal(t, "youtube", data.Content.Items[0].ContentType)
+	assert.Equal(t, "YOUTUBE", data.Content.Items[0].ContentType)
 }
 
 func TestPaginatedContentQuery_WithFilterAndTotalCount(t *testing.T) {


### PR DESCRIPTION
## Summary
- Eliminate manual enum mapping code using gqlgen model bindings
- Add IntID custom scalar for automatic string↔int ID conversion
- Standardize domain enums to UPPERCASE to match GraphQL conventions

## Problem
Resolvers had ~80 lines of repetitive switch statements mapping GraphQL enums to domain enums, plus `strconv.Atoi` calls for every ID filter/input field.

## Solution
1. **IntID scalar** (`pkg/graphql/intid.go`) - Automatically converts GraphQL ID strings to Go ints
2. **gqlgen model bindings** - Bind GraphQL types directly to domain types (SortOrder, ContentSortBy, PerspectiveSortBy, Privacy, ContentType, ReviewStatus)
3. **Uppercase enum values** - Domain enums now use UPPERCASE to match GraphQL conventions
4. **Repository converters** - Handle lowercase↔uppercase conversion for DB storage

## Technical Changes
| Component | Change |
|-----------|--------|
| `pkg/graphql/intid.go` | New custom scalar for ID conversion |
| `gqlgen.yml` | Model bindings for 7 types |
| `schema.graphql` | IntID in filters/mutation inputs |
| `internal/core/domain/*.go` | Uppercase enum values |
| `internal/adapters/repositories/postgres/*.go` | DB conversion helpers |
| `internal/adapters/graphql/resolvers/*.go` | Removed mapping code |

## Impact
**Net reduction: -288 lines** (331 added, 619 removed)

## Test Plan
- [x] All existing tests pass
- [x] Domain enum tests updated for uppercase values
- [x] Resolver tests updated for new enum format
- [ ] Manual test: createPerspective mutation with filters
- [ ] Manual test: perspectives query with sort/filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)