### PR TITLE
fix(02.1): mobile responsive fixes for header and AG Grid pagination

### DIFF
--- a/perspectize-fe/src/app.css
+++ b/perspectize-fe/src/app.css
@@ -15,3 +15,25 @@
 	--color-primary-foreground: oklch(0.983 0.004 236.862);
 }
 
+/* AG Grid pagination mobile responsive fix (GitHub issue #9239) */
+.ag-paging-panel {
+	height: auto !important;
+	flex-wrap: wrap-reverse;
+	row-gap: 1rem;
+	padding: 0.25rem;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+@media (max-width: 768px) {
+	.ag-paging-panel {
+		justify-content: center;
+	}
+}
+
+@media (max-width: 375px) {
+	.ag-paging-panel {
+		font-size: 0.875rem;
+	}
+}
+

--- a/perspectize-fe/src/lib/components/Header.svelte
+++ b/perspectize-fe/src/lib/components/Header.svelte
@@ -11,14 +11,14 @@
 
 <header class="h-16 border-b border-border bg-white sticky top-0 z-50">
 	<div
-		class="h-full px-4 md:px-6 lg:px-8 max-w-screen-xl mx-auto flex items-center justify-between"
+		class="h-full px-4 md:px-6 lg:px-8 max-w-screen-xl mx-auto flex items-center justify-between gap-2 md:gap-4"
 	>
-		<a href="/" class="font-bold text-xl text-foreground hover:text-primary transition-colors">
+		<a href="/" class="font-bold text-base sm:text-lg md:text-xl text-foreground hover:text-primary transition-colors min-w-0 truncate">
 			Perspectize
 		</a>
-		<div class="flex items-center gap-4">
+		<div class="flex items-center gap-2 md:gap-4 shrink-0">
 			<UserSelector />
-			<Button onclick={handleAddVideo}>Add Video</Button>
+			<Button size="sm" onclick={handleAddVideo}>Add Video</Button>
 		</div>
 	</div>
 </header>

--- a/perspectize-fe/tests/components/Header.test.ts
+++ b/perspectize-fe/tests/components/Header.test.ts
@@ -52,9 +52,10 @@ describe('Header component', () => {
 		expect(header?.className).toContain('border-b');
 	});
 
-	it('has responsive padding classes on inner container', () => {
+	it('has responsive padding and gap classes on inner container', () => {
 		const { inner } = renderHeader();
 		expect(inner?.className).toContain('px-4');
+		expect(inner?.className).toContain('gap-2');
 	});
 
 	it('has max-width constraint for large screens', () => {
@@ -65,6 +66,31 @@ describe('Header component', () => {
 	it('renders Add Video button', () => {
 		render(Header);
 		expect(screen.getByRole('button', { name: /add video/i })).toBeInTheDocument();
+	});
+
+	it('logo has min-w-0 for flex shrink support', () => {
+		render(Header);
+		const logo = screen.getByText('Perspectize');
+		expect(logo.className).toContain('min-w-0');
+	});
+
+	it('logo has truncate class for text overflow', () => {
+		render(Header);
+		const logo = screen.getByText('Perspectize');
+		expect(logo.className).toContain('truncate');
+	});
+
+	it('logo has responsive text sizing', () => {
+		render(Header);
+		const logo = screen.getByText('Perspectize');
+		expect(logo.className).toContain('text-base');
+	});
+
+	it('right container has shrink-0 to prevent interactive element shrinking', () => {
+		render(Header);
+		const button = screen.getByRole('button', { name: /add video/i });
+		const rightContainer = button.parentElement;
+		expect(rightContainer?.className).toContain('shrink-0');
 	});
 
 	it('calls toast.info when Add Video button is clicked', async () => {


### PR DESCRIPTION
## Summary
- Fix header overflow at 375px viewport: `min-w-0`/`truncate` on logo, `shrink-0` on interactive container, responsive gap and text sizing
- Fix AG Grid pagination bar: CSS override with `flex-wrap: wrap-reverse`, `height: auto`, and mobile centering
- Add 4 new Header tests verifying responsive CSS classes (13 total, 65 suite total)

## Test plan
- [x] All 65 frontend tests pass (`pnpm run test:run`)
- [x] Plan artifact checks pass (min-w-0, shrink-0, ag-paging-panel present)
- [ ] Visual verification at 375px, 768px, 1280px viewports

<img width="2560" height="1588" alt="ccsv-02 1-01-header-desktop-1280px" src="https://github.com/user-attachments/assets/6315f5c5-3a17-4010-9b6f-322a68eddcff" />

<img width="1536" height="1588" alt="ccsv-02 1-01-header-tablet-768px" src="https://github.com/user-attachments/assets/7f0744a8-975e-4e66-aed6-ffdeb7ff406d" />

<img width="1000" height="1556" alt="ccsv-02 1-01-header-mobile-375px" src="https://github.com/user-attachments/assets/2343e042-e185-4bd0-a2c4-aa50559e1542" />




🤖 Generated with [Claude Code](https://claude.com/claude-code)