### PR TITLE
fix(ci): update Go to 1.25 and PostgreSQL to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: testpass
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: perspectize-go/go.sum
 
       - name: Download dependencies
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: perspectize-go/go.sum
 
       - name: Build


### PR DESCRIPTION
CI was using Go 1.23 while go.mod requires 1.25.0, causing gofmt differences and missing covdata tool. Also align PostgreSQL to v17.

Closes #60

## Summary
<!-- Brief description of changes (1-3 bullet points) -->

## Problem
<!-- What problem does this PR solve? Link to issue if applicable -->

## Solution
<!-- How does this PR solve the problem? -->

## Technical Changes
<!-- List the key technical changes made -->

## Testing
<!-- How was this tested? -->
- [ ] Unit tests pass (`make test`)
- [ ] Manual testing completed
- [ ] GraphQL playground verification (if applicable)

## Checklist
- [ ] Code follows project conventions
- [ ] Tests added/updated for new functionality
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or documented if necessary)

## Related Issues
<!-- Link related issues: Closes #XX, Fixes #XX, Related to #XX -->
