### PR TITLE
docs(03.2): plan Activity Page Beta Quality phase

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -16,7 +16,7 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [x] **Phase 2: Data Layer + Activity** - TanStack Query integration, AG Grid table, user selector
 - [x] **Phase 2.1: Mobile Responsive Fixes** - Fix header overflow, pagination bar, and table layout at 375px (INSERTED)
 - [x] **Phase 3: Add Video Flow** - YouTube URL paste, auto-fetch metadata, toast notifications
-- [ ] **Phase 3.1: Design Token System** - Implement all 27 Figma color variables, Geist + Charter typography, rating colors in code (INSERTED — rescoped)
+- [x] **Phase 3.1: Design Token System** - Implement all 27 Figma color variables, Geist + Charter typography, rating colors in code (INSERTED — rescoped)
 - [ ] **Phase 3.2: Activity Page Beta Quality** - Rebuild Activity page to beta quality with server-side ops, new columns, popover dialog, data provenance (INSERTED)
 - [ ] **Phase 4: Add Perspective Flow** - TanStack Form with ratings, Like, Review, validation
 - [ ] **Phase 5: Testing + Deployment** - Test coverage, CI/CD, hosting, CORS configuration
@@ -119,7 +119,13 @@ Plans:
   9. Add Video dialog: popover-near-button pattern (no overlay), page stays interactive while open
   10. Data provenance visual infrastructure: columns grouped by source, tooltip on header hover, visual tier indicators
   11. Empty state: "No items yet - add the first one!" in table body area
-**Plans**: TBD
+**Plans**: 4 plans in 3 waves
+
+Plans:
+- [ ] 03.2-01-PLAN.md — Backend: expose YouTube fields (channelTitle, publishedAt, tags, description) + extend sort/filter
+- [ ] 03.2-02-PLAN.md — Frontend: popover dialog redesign (replace modal with non-modal popover)
+- [ ] 03.2-03-PLAN.md — Frontend: ActivityTable rewrite (server-side pagination, new columns, compact rows, sticky headers, provenance)
+- [ ] 03.2-04-PLAN.md — Integration polish, test coverage, visual verification checkpoint
 
 ### Phase 4: Add Perspective Flow
 **Goal**: Users can create perspectives on videos with ratings, Like text, and Review text
@@ -250,7 +256,7 @@ Phases 6–10 address the 77 issues cataloged in `.planning/codebase/CONCERNS.md
 - [ ] H-07: Race condition on user uniqueness check (TOCTOU)
 - [ ] H-08: YouTube API response stored verbatim (~5KB bloat per item)
 - [ ] M-04: `deletePerspective` uses `ID` scalar instead of `IntID`
-- [ ] M-08: Missing nested field resolvers (perspective→user, perspective→content)
+- [ ] M-08: Missing nested field resolvers (perspective->user, perspective->content)
 - [ ] M-11: Missing input length validation
 - [ ] M-13: Unbounded JSON field (duplicate of H-08)
 - [ ] M-16: Update does not check `RowsAffected`
@@ -263,7 +269,7 @@ Phases 6–10 address the 77 issues cataloged in `.planning/codebase/CONCERNS.md
   1. Authentication middleware validates JWT/session on all mutations (C-01)
   2. Authorization checks on all mutations — users can only modify their own data (C-01)
   3. GraphQL query complexity limit enforced (C-04)
-  4. CORS restricted to explicit frontend origin (C-05 — may already be done in Phase 5)
+  4. CORS restricted to explicit frontend origin (C-05 -- may already be done in Phase 5)
   5. GraphQL playground disabled in production (C-09)
   6. Introspection disabled in production (C-10)
   7. User email addresses only visible to authenticated user for their own account (H-10)
@@ -296,7 +302,7 @@ Phases 6–10 address the 77 issues cataloged in `.planning/codebase/CONCERNS.md
 ### Phase 10: Frontend Quality & Test Coverage
 **Goal**: Fix frontend vulnerabilities, add codegen, error boundaries, and close all test coverage gaps
 **Depends on**: Phase 8 (schema fixes enable codegen; nested resolvers enable frontend cleanup)
-**Source**: CONCERNS.md C-03, H-17, H-18, H-22, H-23, H-24, M-18–M-26, T-01–T-06, L-*
+**Source**: CONCERNS.md C-03, H-17, H-18, H-22, H-23, H-24, M-18-M-26, T-01-T-06, L-*
 **Success Criteria** (what must be TRUE):
   1. AG Grid cellRenderer uses safe DOM APIs, no raw innerHTML interpolation (C-03)
   2. `+error.svelte` error boundary exists with retry UI (H-17, M-23)
@@ -331,7 +337,7 @@ Phases 6–10 address the 77 issues cataloged in `.planning/codebase/CONCERNS.md
 - [ ] M-24: Dead code (`AGGridTest.svelte`)
 - [ ] M-25: HTTP fallback for GraphQL endpoint
 - [ ] M-26: Retry configuration retries all errors (should only retry 5xx)
-- [ ] T-01: `PerspectiveService.Update()` — zero tests
+- [ ] T-01: `PerspectiveService.Update()` -- zero tests
 - [ ] T-02: No resolver tests
 - [ ] T-03: No `helpers.go` conversion tests
 - [ ] T-04: No repository-layer tests
@@ -351,7 +357,7 @@ Phases execute in numeric order: 1 -> 2 -> 2.1 -> 3 -> 3.1 -> 3.2 -> 4 -> 5 -> 6
 | 2.1 Mobile Responsive Fixes | 2/2 | Complete | 2026-02-07 |
 | 3. Add Video Flow | 2/2 | Complete | 2026-02-07 |
 | 3.1 Design Token System | 2/2 | Complete | 2026-02-12 |
-| 3.2 Activity Page Beta Quality | 0/0 | Not started | - |
+| 3.2 Activity Page Beta Quality | 0/4 | Planned | - |
 | 4. Add Perspective Flow | 0/2 | Not started | - |
 | 5. Testing + Deployment | 1/3 | In progress | - |
 | 6. Error Handling & Data Integrity | 0/0 | Not started | - |

--- a/.planning/phases/03.2-activity-page-beta-quality/03.2-01-PLAN.md
+++ b/.planning/phases/03.2-activity-page-beta-quality/03.2-01-PLAN.md
@@ -1,0 +1,276 @@
+---
+phase: 03.2-activity-page-beta-quality
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - perspectize-go/schema.graphql
+  - perspectize-go/internal/adapters/graphql/resolvers/helpers.go
+  - perspectize-go/internal/core/domain/pagination.go
+  - perspectize-go/internal/adapters/repositories/postgres/content_repository.go
+  - perspectize-go/internal/adapters/graphql/generated/generated.go
+  - perspectize-go/internal/adapters/graphql/model/models_gen.go
+  - perspective-go/internal/adapters/graphql/resolvers/schema.resolvers.go
+autonomous: true
+
+must_haves:
+  truths:
+    - "GraphQL content query returns channelTitle, publishedAt, tags, and description fields extracted from stored YouTube response JSON"
+    - "Content list query accepts search filter for text search on name field"
+    - "Content list query sorts by VIEW_COUNT, LIKE_COUNT, or PUBLISHED_AT in addition to existing sort fields"
+    - "All existing backend tests pass after changes"
+  artifacts:
+    - path: "perspectize-go/schema.graphql"
+      provides: "Content type with channelTitle, publishedAt, tags, description fields; extended ContentSortBy enum; extended ContentFilter with search"
+      contains: "channelTitle"
+    - path: "perspectize-go/internal/adapters/graphql/resolvers/helpers.go"
+      provides: "domainToModel extracts channelTitle, publishedAt, tags, description from response JSON"
+      contains: "ChannelTitle"
+    - path: "perspectize-go/internal/core/domain/pagination.go"
+      provides: "New ContentSortBy constants and ContentFilter search field"
+      contains: "ContentSortByViewCount"
+    - path: "perspective-go/internal/adapters/repositories/postgres/content_repository.go"
+      provides: "Sort by view_count, like_count, published_at; filter by name ILIKE"
+      contains: "view_count"
+  key_links:
+    - from: "perspective-go/schema.graphql"
+      to: "perspectize-go/internal/adapters/graphql/model/models_gen.go"
+      via: "make graphql-gen code generation"
+      pattern: "ChannelTitle.*string"
+    - from: "perspectize-go/internal/adapters/graphql/resolvers/helpers.go"
+      to: "perspectize-go/internal/adapters/graphql/model/models_gen.go"
+      via: "sets new fields on model.Content"
+      pattern: "m\\.ChannelTitle"
+---
+
+<objective>
+Extend the Go backend to expose new YouTube metadata fields through GraphQL and support additional sorting/filtering needed by the Activity table.
+
+Purpose: The Activity table needs 6 new data fields (channelTitle, publishedAt, tags, description, viewCount in list query, likeCount in list query) and server-side sort/filter capabilities that don't exist yet. The raw YouTube API response already contains all this data in the `response` JSONB column -- we just need to extract and expose it through GraphQL.
+
+Output: Updated GraphQL schema, domain model, helpers, and repository that expose channelTitle, publishedAt, tags, description; support sorting by VIEW_COUNT, LIKE_COUNT, PUBLISHED_AT; and support text search filtering on content name.
+</objective>
+
+<execution_context>
+@/Users/jamesjordan/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/jamesjordan/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-CONTEXT.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-RESEARCH.md
+@perspectize-go/CLAUDE.md
+
+Key existing files to reference:
+@perspectize-go/schema.graphql
+@perspectize-go/internal/adapters/graphql/resolvers/helpers.go
+@perspectize-go/internal/core/domain/pagination.go
+@perspectize-go/internal/core/domain/content.go
+@perspectize-go/internal/adapters/repositories/postgres/content_repository.go
+@perspectize-go/internal/adapters/graphql/resolvers/schema.resolvers.go
+@perspectize-go/internal/adapters/youtube/client.go
+@perspective-go/gqlgen.yml
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Extend GraphQL schema with new Content fields, sort options, and search filter</name>
+  <files>
+    perspective-go/schema.graphql
+    perspectize-go/internal/core/domain/pagination.go
+    perspectize-go/gqlgen.yml
+  </files>
+  <action>
+    **1. Update `schema.graphql` Content type** — Add these fields to the `Content` type:
+    ```graphql
+    channelTitle: String
+    publishedAt: String
+    tags: [String!]
+    description: String
+    ```
+    Place them after `commentCount` and before `response`.
+
+    **2. Extend `ContentSortBy` enum** — Add new sort options:
+    ```graphql
+    enum ContentSortBy {
+      CREATED_AT
+      UPDATED_AT
+      NAME
+      VIEW_COUNT
+      LIKE_COUNT
+      PUBLISHED_AT
+    }
+    ```
+
+    **3. Extend `ContentFilter` input** — Add text search capability:
+    ```graphql
+    input ContentFilter {
+      contentType: ContentType
+      minLengthSeconds: Int
+      maxLengthSeconds: Int
+      search: String
+    }
+    ```
+    The `search` field will perform case-insensitive partial match on the `name` column.
+
+    **4. Update `pagination.go`** — Add new domain constants and filter field:
+    - Add `ContentSortByViewCount ContentSortBy = "VIEW_COUNT"`
+    - Add `ContentSortByLikeCount ContentSortBy = "LIKE_COUNT"`
+    - Add `ContentSortByPublishedAt ContentSortBy = "PUBLISHED_AT"`
+    - Add `Search *string` field to `ContentFilter` struct
+
+    **5. Run `make graphql-gen`** from `perspectize-go/` directory to regenerate the generated code. This updates `models_gen.go` with the new Content fields and `generated.go` with the new enum values.
+
+    **6. Update `gqlgen.yml`** if needed — The new enum values VIEW_COUNT, LIKE_COUNT, PUBLISHED_AT must map to the domain constants. Since ContentSortBy is already bound in gqlgen.yml to the domain type, and the UPPERCASE values match, no gqlgen.yml change should be needed. Verify after code generation.
+
+    **IMPORTANT:** After `make graphql-gen`, the `schema.resolvers.go` Content resolver signature will be updated with the new filter fields. The resolver already correctly passes the filter to the service, so no resolver change is needed for the filter. However, verify the filter mapping section handles the new `search` field.
+  </action>
+  <verify>
+    - `cd perspectize-go && make graphql-gen` completes without errors
+    - `grep "ChannelTitle" internal/adapters/graphql/model/models_gen.go` shows the new field
+    - `grep "Tags" internal/adapters/graphql/model/models_gen.go` shows tags field as `[]string`
+    - `grep "ContentSortByViewCount" internal/core/domain/pagination.go` shows the new constant
+    - `grep "Search" internal/core/domain/pagination.go` shows the new filter field
+  </verify>
+  <done>
+    GraphQL schema has channelTitle, publishedAt, tags, description on Content type; ContentSortBy has VIEW_COUNT, LIKE_COUNT, PUBLISHED_AT; ContentFilter has search field; code generation succeeds; domain model updated with matching constants and filter struct field.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Extract new fields in helpers.go and wire sort/filter in repository</name>
+  <files>
+    perspectize-go/internal/adapters/graphql/resolvers/helpers.go
+    perspectize-go/internal/adapters/repositories/postgres/content_repository.go
+    perspectize-go/internal/adapters/graphql/resolvers/schema.resolvers.go
+  </files>
+  <action>
+    **1. Update `helpers.go` domainToModel** — In the existing YouTube response JSON parsing block (where viewCount, likeCount, commentCount are already extracted), also extract:
+    - `channelTitle` from `resp.Items[0].Snippet.ChannelTitle` (string)
+    - `publishedAt` from `resp.Items[0].Snippet.PublishedAt` (string, ISO 8601 format)
+    - `tags` from `resp.Items[0].Snippet.Tags` ([]string)
+    - `description` from `resp.Items[0].Snippet.Description` (string)
+
+    Update the anonymous struct used for parsing to include:
+    ```go
+    var resp struct {
+      Items []struct {
+        Snippet struct {
+          ChannelTitle string   `json:"channelTitle"`
+          PublishedAt  string   `json:"publishedAt"`
+          Tags         []string `json:"tags"`
+          Description  string   `json:"description"`
+        } `json:"snippet"`
+        Statistics struct {
+          ViewCount    string `json:"viewCount"`
+          LikeCount    string `json:"likeCount"`
+          CommentCount string `json:"commentCount"`
+        } `json:"statistics"`
+      } `json:"items"`
+    }
+    ```
+
+    Then set the model fields:
+    ```go
+    snippet := resp.Items[0].Snippet
+    if snippet.ChannelTitle != "" {
+      m.ChannelTitle = &snippet.ChannelTitle
+    }
+    if snippet.PublishedAt != "" {
+      m.PublishedAt = &snippet.PublishedAt
+    }
+    if len(snippet.Tags) > 0 {
+      m.Tags = snippet.Tags
+    }
+    if snippet.Description != "" {
+      m.Description = &snippet.Description
+    }
+    ```
+
+    **2. Update `content_repository.go` sortColumnName** — Add mappings for new sort fields. Note: view_count, like_count, published_at are NOT database columns -- they live in the `response` JSONB. For sorting by these, use JSONB extraction expressions:
+    ```go
+    case domain.ContentSortByViewCount:
+      return "CAST(response->'items'->0->'statistics'->>'viewCount' AS BIGINT)"
+    case domain.ContentSortByLikeCount:
+      return "CAST(response->'items'->0->'statistics'->>'likeCount' AS BIGINT)"
+    case domain.ContentSortByPublishedAt:
+      return "response->'items'->0->'snippet'->>'publishedAt'"
+    ```
+
+    IMPORTANT: The CAST to BIGINT is needed for numeric sorting (otherwise it sorts alphabetically). For publishedAt, the ISO 8601 format sorts correctly as a string.
+
+    IMPORTANT: These JSONB expressions are safe from SQL injection because they are hardcoded column expressions in a switch statement, not user input. However, they may be NULL for rows without a response. Add `NULLS LAST` to the ORDER BY for these sort fields. Update the `List` method's ORDER BY construction to include NULLS LAST when sorting by JSONB-extracted fields.
+
+    **3. Add search filter to `content_repository.go` List method** — In the filter section of the List method, add handling for the Search field:
+    ```go
+    if params.Filter.Search != nil && *params.Filter.Search != "" {
+      conditions = append(conditions, fmt.Sprintf("name ILIKE $%d", argIdx))
+      args = append(args, "%"+*params.Filter.Search+"%")
+      argIdx++
+    }
+    ```
+    Also add the same to the count query conditions.
+
+    **4. Update `schema.resolvers.go` Content resolver** — In the filter mapping section, add:
+    ```go
+    if filter.Search != nil {
+      params.Filter.Search = filter.Search
+    }
+    ```
+
+    **5. Verify all tests pass** — Run `cd perspectize-go && make test` to ensure no regressions. The existing tests mock the response JSON, so the new field extraction should be backward-compatible (fields are nil/empty when not present in response).
+  </action>
+  <verify>
+    - `cd perspectize-go && make test` passes all tests
+    - Start the backend server and run a GraphQL query to verify new fields:
+      ```bash
+      curl -s -X POST http://localhost:8080/graphql \
+        -H "Content-Type: application/json" \
+        -d '{"query":"{ content(first:1) { items { id name channelTitle publishedAt tags description viewCount likeCount } } }"}' | head -200
+      ```
+      Should return channelTitle, publishedAt, tags, description values (or null if no YouTube data)
+    - Test sort by view count:
+      ```bash
+      curl -s -X POST http://localhost:8080/graphql \
+        -H "Content-Type: application/json" \
+        -d '{"query":"{ content(first:3, sortBy:VIEW_COUNT, sortOrder:DESC) { items { id name viewCount } } }"}'
+      ```
+    - Test search filter:
+      ```bash
+      curl -s -X POST http://localhost:8080/graphql \
+        -H "Content-Type: application/json" \
+        -d '{"query":"{ content(first:3, filter:{search:\"test\"}) { items { id name } totalCount } }"}'
+      ```
+  </verify>
+  <done>
+    domainToModel extracts channelTitle, publishedAt, tags, description from response JSON. Repository sorts by view_count, like_count, published_at using JSONB extraction. Repository filters by name ILIKE for text search. All existing tests pass. GraphQL queries return the new fields and respect the new sort/filter options.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cd perspectize-go && make test` — all existing tests pass
+- GraphQL playground at http://localhost:8080/graphql returns new fields
+- Sorting by VIEW_COUNT, LIKE_COUNT, PUBLISHED_AT returns correctly ordered data
+- Search filter returns matching results and correct totalCount
+- New fields are null-safe (no crash when response JSON lacks expected structure)
+</verification>
+
+<success_criteria>
+- GraphQL Content type has channelTitle, publishedAt, tags, description fields
+- ContentSortBy enum includes VIEW_COUNT, LIKE_COUNT, PUBLISHED_AT
+- ContentFilter input includes search field
+- All fields extracted from existing response JSONB (no new YouTube API calls)
+- All 78+ backend tests pass
+- Frontend test coverage gate: `cd perspective-fe && pnpm run test:coverage` exits 0 (not modified, should still pass)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03.2-activity-page-beta-quality/03.2-01-SUMMARY.md`
+</output>

--- a/.planning/phases/03.2-activity-page-beta-quality/03.2-02-PLAN.md
+++ b/.planning/phases/03.2-activity-page-beta-quality/03.2-02-PLAN.md
@@ -1,0 +1,326 @@
+---
+phase: 03.2-activity-page-beta-quality
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - perspectize-fe/src/lib/components/AddVideoPopover.svelte
+  - perspectize-fe/src/lib/components/Header.svelte
+  - perspective-fe/src/lib/components/shadcn/popover/index.ts
+  - perspectize-fe/src/lib/components/shadcn/popover/popover-content.svelte
+  - perspectize-fe/src/lib/components/shadcn/index.ts
+  - perspectize-fe/tests/components/AddVideoDialog.test.ts
+  - perspectize-fe/tests/components/Header.test.ts
+autonomous: true
+
+must_haves:
+  truths:
+    - "Clicking Add Video button opens a non-modal popover near the button, not a centered modal"
+    - "Page stays interactive while popover is open (no overlay, no background darkening)"
+    - "Clicking outside the popover dismisses it"
+    - "Submitting a valid YouTube URL adds the video (toast confirmation) and closes the popover"
+    - "URL input does not show browser autofill suggestions (autocomplete=off)"
+    - "Invalid URL shows inline error, popover stays open"
+  artifacts:
+    - path: "perspective-fe/src/lib/components/AddVideoPopover.svelte"
+      provides: "Non-modal popover with YouTube URL input, mutation, validation"
+      min_lines: 50
+    - path: "perspectize-fe/src/lib/components/Header.svelte"
+      provides: "Header with AddVideoPopover replacing AddVideoDialog"
+      contains: "AddVideoPopover"
+    - path: "perspectize-fe/src/lib/components/shadcn/popover/index.ts"
+      provides: "shadcn Popover component exports"
+      contains: "Popover"
+  key_links:
+    - from: "perspectize-fe/src/lib/components/AddVideoPopover.svelte"
+      to: "/api GraphQL mutation"
+      via: "createMutation with CREATE_CONTENT_FROM_YOUTUBE"
+      pattern: "createMutation"
+    - from: "perspectize-fe/src/lib/components/Header.svelte"
+      to: "perspectize-fe/src/lib/components/AddVideoPopover.svelte"
+      via: "import and render"
+      pattern: "AddVideoPopover"
+---
+
+<objective>
+Replace the full-screen modal Add Video dialog with a non-modal popover that appears near the Add Video button, keeping the page interactive.
+
+Purpose: The user explicitly wants to interact with the page while the dialog is open. The current modal with overlay is disruptive and jerks the user into a new context. A popover near the button maintains spatial context and allows page interaction. This pattern will be reused in Phase 4 for Add Perspective.
+
+Output: New AddVideoPopover component using shadcn Popover, updated Header to use it, old AddVideoDialog can be left in place but unused (removal in Phase 10 cleanup).
+</objective>
+
+<execution_context>
+@/Users/jamesjordan/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/jamesjordan/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-CONTEXT.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-RESEARCH.md
+@perspectize-fe/CLAUDE.md
+
+Key existing files:
+@perspectize-fe/src/lib/components/AddVideoDialog.svelte
+@perspectize-fe/src/lib/components/Header.svelte
+@perspectize-fe/src/lib/components/shadcn/index.ts
+@perspectize-fe/src/lib/utils/youtube.ts
+@perspectize-fe/src/lib/queries/content.ts
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Install shadcn Popover and create AddVideoPopover component</name>
+  <files>
+    perspectize-fe/src/lib/components/shadcn/popover/index.ts
+    perspectize-fe/src/lib/components/shadcn/popover/popover-content.svelte
+    perspectize-fe/src/lib/components/shadcn/index.ts
+    perspectize-fe/src/lib/components/AddVideoPopover.svelte
+  </files>
+  <action>
+    **1. Install shadcn Popover component:**
+    ```bash
+    cd perspectize-fe && pnpm dlx shadcn-svelte@latest add popover
+    ```
+    This will create files in `src/lib/components/shadcn/popover/`. If the CLI puts them elsewhere (e.g., `src/lib/components/ui/popover/`), move them to `shadcn/popover/` to match the project convention (shadcn components live in `shadcn/` directory, not `ui/`).
+
+    **2. Update the shadcn barrel export** in `src/lib/components/shadcn/index.ts`:
+    Add Popover exports after the Label export:
+    ```typescript
+    export { default as Popover } from "./popover/index.js";
+    ```
+    Actually, shadcn Popover uses namespace exports. Check the generated popover/index.ts for the exact export pattern. If it exports `Root`, `Trigger`, `Content` etc., then in the barrel file, re-export them as a namespace:
+    ```typescript
+    export * as Popover from "./popover/index.js";
+    ```
+    Or if the barrel pattern doesn't support namespace exports cleanly, import the Popover directly in AddVideoPopover.svelte from `$lib/components/shadcn/popover`.
+
+    **3. Create `AddVideoPopover.svelte`** — This component replaces AddVideoDialog. Port the mutation logic from AddVideoDialog.svelte but use Popover instead of Dialog:
+
+    ```svelte
+    <script lang="ts">
+      import { createMutation, useQueryClient } from '@tanstack/svelte-query';
+      import { toast } from 'svelte-sonner';
+      import * as Popover from '$lib/components/shadcn/popover';
+      import { Button } from '$lib/components/shadcn';
+      import { Input } from '$lib/components/shadcn';
+      import { Label } from '$lib/components/shadcn';
+      import { graphqlClient } from '$lib/queries/client';
+      import { CREATE_CONTENT_FROM_YOUTUBE } from '$lib/queries/content';
+      import { validateYouTubeUrl } from '$lib/utils/youtube';
+
+      let open = $state(false);
+      let url = $state('');
+      let error = $state('');
+
+      // Reset form when popover opens
+      $effect(() => {
+        if (open) {
+          url = '';
+          error = '';
+        }
+      });
+
+      const queryClient = useQueryClient();
+
+      const mutation = createMutation(() => ({
+        mutationFn: async (videoUrl: string) => {
+          return graphqlClient.request(CREATE_CONTENT_FROM_YOUTUBE, {
+            input: { url: videoUrl }
+          });
+        },
+        onSuccess: (data: any) => {
+          const name = data?.createContentFromYouTube?.name ?? 'video';
+          toast.success(`Added: ${name}`);
+          queryClient.invalidateQueries({ queryKey: ['content'] });
+          open = false;
+        },
+        onError: (err: Error) => {
+          const message = err.message.toLowerCase();
+          if (message.includes('already exists')) {
+            toast.error('This video has already been added');
+          } else if (message.includes('invalid youtube url') || message.includes('video not found')) {
+            toast.error('Invalid YouTube URL or video not found');
+          } else {
+            toast.error('Failed to add video. Please try again.');
+          }
+        }
+      }));
+
+      function handleSubmit(e: Event) {
+        e.preventDefault();
+        if (!validateYouTubeUrl(url)) {
+          error = 'Please enter a valid YouTube URL';
+          return;
+        }
+        error = '';
+        mutation.mutate(url);
+      }
+    </script>
+
+    <Popover.Root bind:open>
+      <Popover.Trigger asChild let:builder>
+        <Button builders={[builder]} size="sm">Add Video</Button>
+      </Popover.Trigger>
+      <Popover.Content class="w-80" sideOffset={8} align="end">
+        <form onsubmit={handleSubmit}>
+          <div class="grid gap-3">
+            <div class="space-y-1">
+              <Label for="video-url" class="text-sm font-medium">YouTube URL</Label>
+              <Input
+                id="video-url"
+                type="url"
+                bind:value={url}
+                autocomplete="off"
+                placeholder="https://youtube.com/watch?v=..."
+                disabled={mutation.isPending}
+              />
+              {#if error}
+                <p class="text-xs text-destructive">{error}</p>
+              {/if}
+            </div>
+            <div class="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onclick={() => (open = false)}
+                disabled={mutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={mutation.isPending || !url.trim()}>
+                {mutation.isPending ? 'Adding...' : 'Add'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </Popover.Content>
+    </Popover.Root>
+    ```
+
+    KEY DETAILS:
+    - `align="end"` positions the popover to the right edge of the trigger (near the button)
+    - `sideOffset={8}` gives 8px gap between button and popover
+    - `autocomplete="off"` prevents browser autofill on the URL input
+    - No overlay/portal — page stays interactive
+    - Click-outside dismiss is default Popover behavior
+    - Same mutation logic, error handling, and toast feedback as AddVideoDialog
+    - Uses `type="url"` for semantic HTML
+
+    NOTE: Check the exact shadcn-svelte Popover API. The Svelte 5 version may use `{#snippet}` syntax instead of `asChild let:builder`. If so, adapt:
+    ```svelte
+    <Popover.Trigger>
+      {#snippet child({ props })}
+        <Button {...props} size="sm">Add Video</Button>
+      {/snippet}
+    </Popover.Trigger>
+    ```
+    Consult the installed bits-ui version for the correct pattern.
+  </action>
+  <verify>
+    - `cd perspectize-fe && pnpm run check` passes type checking
+    - `ls perspectize-fe/src/lib/components/shadcn/popover/` shows popover component files
+    - `ls perspectize-fe/src/lib/components/AddVideoPopover.svelte` exists
+  </verify>
+  <done>
+    shadcn Popover installed in shadcn/popover/ directory. AddVideoPopover.svelte created with non-modal popover, mutation logic, autocomplete=off, click-outside dismiss, form validation, and toast feedback. Type checking passes.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire Header to use AddVideoPopover and update tests</name>
+  <files>
+    perspectize-fe/src/lib/components/Header.svelte
+    perspectize-fe/tests/components/Header.test.ts
+    perspectize-fe/tests/components/AddVideoDialog.test.ts
+  </files>
+  <action>
+    **1. Update Header.svelte** — Replace AddVideoDialog with AddVideoPopover:
+
+    Remove the import of AddVideoDialog and the `dialogOpen` state. Remove the `<AddVideoDialog bind:open={dialogOpen} />` at the bottom. Remove the `<Button onclick={() => (dialogOpen = true)}>` and replace the entire Add Video button area with the AddVideoPopover component.
+
+    The Header should become:
+    ```svelte
+    <script lang="ts">
+      import UserSelector from '$lib/components/UserSelector.svelte';
+      import AddVideoPopover from '$lib/components/AddVideoPopover.svelte';
+    </script>
+
+    <header class="h-16 border-b border-border bg-white sticky top-0 z-50">
+      <div class="h-full px-4 md:px-6 lg:px-8 max-w-screen-xl mx-auto flex items-center justify-between gap-2 md:gap-4">
+        <a href="/" class="font-bold text-base sm:text-lg md:text-xl text-foreground hover:text-primary transition-colors min-w-0 truncate">
+          Perspectize
+        </a>
+        <div class="flex items-center gap-2 md:gap-4 shrink-0">
+          <UserSelector />
+          <AddVideoPopover />
+        </div>
+      </div>
+    </header>
+    ```
+
+    Note: AddVideoPopover renders its own trigger button (the "Add Video" button is inside the Popover.Trigger). No separate button needed in Header.
+
+    **2. Update Header.test.ts** — Update tests to expect "AddVideoPopover" instead of "AddVideoDialog". The test may check for the "Add Video" button text -- this should still work since the button is rendered by AddVideoPopover. Remove any tests that assert `dialogOpen` state or dialog visibility. Instead, test that the AddVideoPopover component is rendered in the Header.
+
+    **3. Update AddVideoDialog.test.ts** — Either:
+    - Rename to AddVideoPopover.test.ts and update to test the new component, OR
+    - Keep AddVideoDialog.test.ts for the old component (if not deleted) and create a new AddVideoPopover.test.ts
+
+    Create `tests/components/AddVideoPopover.test.ts` with tests:
+    - Component renders with "Add Video" button text
+    - Component exports are correct (no required props)
+
+    For the popover interaction tests (opening, form validation, submission), these require complex DOM interaction that may be difficult in jsdom. Focus on:
+    - Rendering without errors
+    - Button text is "Add Video"
+    - Component can be imported and instantiated
+
+    **4. Run test coverage gate:**
+    ```bash
+    cd perspectize-fe && pnpm run test:coverage
+    ```
+    Must pass 80% stmts/lines/functions, 75% branches.
+  </action>
+  <verify>
+    - `cd perspectize-fe && pnpm run test:coverage` exits 0
+    - `cd perspective-fe && pnpm run check` passes type checking
+    - Header.svelte imports AddVideoPopover, not AddVideoDialog
+    - No Button with onclick handler for dialog in Header (the trigger is inside AddVideoPopover)
+  </verify>
+  <done>
+    Header uses AddVideoPopover instead of AddVideoDialog. Tests updated. Coverage gate passes. The Add Video button opens a popover near the button without any modal overlay.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cd perspectize-fe && pnpm run check` — type checking passes
+- `cd perspectize-fe && pnpm run test:coverage` — coverage gate passes (80% stmts/lines/functions, 75% branches)
+- Dev server: clicking "Add Video" opens a popover near the button, not a centered modal
+- Page behind the popover is still interactive (no overlay, no darkening)
+- Clicking outside the popover dismisses it
+- Submitting a valid YouTube URL shows success toast and closes popover
+- URL input has autocomplete="off" attribute
+</verification>
+
+<success_criteria>
+- AddVideoPopover component exists and uses shadcn Popover (not Dialog)
+- Header renders AddVideoPopover instead of AddVideoDialog
+- Popover appears near the Add Video button (align="end", sideOffset)
+- No modal overlay or background darkening
+- Page stays interactive while popover is open
+- All existing mutation/validation/toast behavior preserved
+- Frontend test coverage gate passes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03.2-activity-page-beta-quality/03.2-02-SUMMARY.md`
+</output>

--- a/.planning/phases/03.2-activity-page-beta-quality/03.2-03-PLAN.md
+++ b/.planning/phases/03.2-activity-page-beta-quality/03.2-03-PLAN.md
@@ -1,0 +1,823 @@
+---
+phase: 03.2-activity-page-beta-quality
+plan: 03
+type: execute
+wave: 2
+depends_on: ["03.2-01"]
+files_modified:
+  - perspectize-fe/src/lib/queries/content.ts
+  - perspective-fe/src/lib/components/ActivityTable.svelte
+  - perspective-fe/src/lib/utils/formatting.ts
+  - perspective-fe/src/routes/+page.svelte
+  - perspective-fe/src/app.css
+  - perspective-fe/tests/unit/formatting.test.ts
+  - perspective-fe/tests/components/ActivityTable.test.ts
+autonomous: true
+
+must_haves:
+  truths:
+    - "Column header clicks trigger server-side sorting via GraphQL API (not client-side)"
+    - "Per-column floating filters send search/filter params to backend (no global search bar)"
+    - "Pagination loads one page at a time from backend with total count displayed"
+    - "Page size selector offers 10/25/50 options"
+    - "6 default visible columns: Item (title+thumbnail), Type (YouTube icon), Length, Views, Likes, Date (YouTube publish date)"
+    - "5 hidden columns available via column menu: Channel, Date Added, Date Updated, Tags, Description"
+    - "Compact rows ~40-48px height with small thumbnails ~32-40px"
+    - "Page header (h-16) and AG Grid column headers are sticky, table body scrolls independently"
+    - "Empty state shows 'No items yet - add the first one!' in table body area"
+    - "Column header tooltips explain data provenance (e.g. 'from YouTube API')"
+  artifacts:
+    - path: "perspective-fe/src/lib/queries/content.ts"
+      provides: "LIST_CONTENT query requesting all new fields (channelTitle, publishedAt, tags, description, viewCount, likeCount) with filter param"
+      contains: "channelTitle"
+    - path: "perspective-fe/src/lib/components/ActivityTable.svelte"
+      provides: "AG Grid with server-side data fetching, 11 column definitions, floating filters, compact rows, sticky headers, empty state overlay"
+      min_lines: 100
+    - path: "perspective-fe/src/routes/+page.svelte"
+      provides: "Activity page with manual pagination controls, no global search bar"
+      contains: "ActivityTable"
+    - path: "perspective-fe/src/lib/utils/formatting.ts"
+      provides: "Formatters for view count, like count, YouTube icon renderer, thumbnail renderer"
+      contains: "formatCount"
+  key_links:
+    - from: "perspective-fe/src/lib/components/ActivityTable.svelte"
+      to: "perspective-fe/src/lib/queries/content.ts"
+      via: "graphqlClient.request(LIST_CONTENT, variables)"
+      pattern: "graphqlClient\\.request"
+    - from: "perspective-fe/src/routes/+page.svelte"
+      to: "perspective-fe/src/lib/components/ActivityTable.svelte"
+      via: "component rendering"
+      pattern: "ActivityTable"
+---
+
+<objective>
+Rewrite the Activity table for server-side data operations with new YouTube columns, compact rows, sticky headers, floating filters, and data provenance infrastructure.
+
+Purpose: Transform the Activity page from a client-side-fetched-all-data table into a server-driven table where each page, sort, and filter goes through the GraphQL API. Add the 6 new YouTube-sourced columns, compact row styling matching Figma, and provenance tooltips.
+
+Output: Completely rewritten ActivityTable component with manual server-side pagination, 11 column definitions (6 visible, 5 hidden), floating filters, compact rows, sticky headers, empty state overlay, and data provenance tooltips on column headers.
+</objective>
+
+<execution_context>
+@/Users/jamesjordan/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/jamesjordan/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-CONTEXT.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-RESEARCH.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-01-SUMMARY.md
+@perspectize-fe/CLAUDE.md
+
+Key existing files:
+@perspective-fe/src/lib/components/ActivityTable.svelte
+@perspective-fe/src/lib/queries/content.ts
+@perspective-fe/src/routes/+page.svelte
+@perspective-fe/src/lib/utils/formatting.ts
+@perspective-fe/src/app.css
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update GraphQL query and formatting utilities for new columns</name>
+  <files>
+    perspective-fe/src/lib/queries/content.ts
+    perspective-fe/src/lib/utils/formatting.ts
+    perspective-fe/tests/unit/formatting.test.ts
+  </files>
+  <action>
+    **1. Update LIST_CONTENT query in `content.ts`** — Add the new fields and filter parameter:
+    ```typescript
+    export const LIST_CONTENT = gql`
+      query ListContent(
+        $first: Int
+        $after: String
+        $sortBy: ContentSortBy = UPDATED_AT
+        $sortOrder: SortOrder = DESC
+        $includeTotalCount: Boolean = true
+        $filter: ContentFilter
+      ) {
+        content(
+          first: $first
+          after: $after
+          sortBy: $sortBy
+          sortOrder: $sortOrder
+          includeTotalCount: $includeTotalCount
+          filter: $filter
+        ) {
+          items {
+            id
+            name
+            url
+            contentType
+            length
+            lengthUnits
+            viewCount
+            likeCount
+            channelTitle
+            publishedAt
+            tags
+            description
+            createdAt
+            updatedAt
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            endCursor
+            startCursor
+          }
+          totalCount
+        }
+      }
+    `;
+    ```
+
+    Key changes: Added `filter` variable, added `viewCount`, `likeCount`, `channelTitle`, `publishedAt`, `tags`, `description` to item fields, added `hasPreviousPage` and `startCursor` to pageInfo.
+
+    **2. Add ContentItem TypeScript interface** — Export a TypeScript interface for the content row data:
+    ```typescript
+    export interface ContentItem {
+      id: string;
+      name: string;
+      url: string | null;
+      contentType: string;
+      length: number | null;
+      lengthUnits: string | null;
+      viewCount: number | null;
+      likeCount: number | null;
+      channelTitle: string | null;
+      publishedAt: string | null;
+      tags: string[] | null;
+      description: string | null;
+      createdAt: string;
+      updatedAt: string;
+    }
+
+    export interface ContentResponse {
+      content: {
+        items: ContentItem[];
+        pageInfo: {
+          hasNextPage: boolean;
+          hasPreviousPage: boolean;
+          endCursor: string | null;
+          startCursor: string | null;
+        };
+        totalCount: number | null;
+      };
+    }
+    ```
+
+    **3. Add formatting utilities** — Add to `formatting.ts`:
+
+    ```typescript
+    /**
+     * Format large numbers with K/M suffixes.
+     * e.g., 1234 -> "1.2K", 1234567 -> "1.2M"
+     */
+    export function formatCount(count: number | null): string {
+      if (count === null || count === undefined) return '--';
+      if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+      if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+      return count.toLocaleString();
+    }
+
+    /**
+     * Format YouTube publish date (ISO 8601) to short date.
+     */
+    export function formatPublishDate(isoString: string | null): string {
+      if (!isoString) return '--';
+      return formatDate(isoString);
+    }
+
+    /**
+     * Format tags array to comma-separated string.
+     */
+    export function formatTags(tags: string[] | null): string {
+      if (!tags || tags.length === 0) return '--';
+      return tags.join(', ');
+    }
+
+    /**
+     * Truncate description to maxLength with ellipsis.
+     */
+    export function truncateDescription(desc: string | null, maxLength: number = 80): string {
+      if (!desc) return '--';
+      if (desc.length <= maxLength) return desc;
+      return desc.slice(0, maxLength) + '...';
+    }
+    ```
+
+    **4. Add AG Grid cell renderer for Item column (title + thumbnail):**
+    Update `nameCellRenderer` to show a small thumbnail next to the title. The YouTube thumbnail URL can be derived from the video URL:
+    ```typescript
+    /**
+     * Extract YouTube video ID from a URL for thumbnail generation.
+     */
+    function extractVideoIdFromUrl(url: string | null): string | null {
+      if (!url) return null;
+      try {
+        const urlObj = new URL(url);
+        if (urlObj.hostname === 'youtu.be') return urlObj.pathname.slice(1);
+        return urlObj.searchParams.get('v');
+      } catch {
+        return null;
+      }
+    }
+
+    /**
+     * AG Grid cell renderer for Item column (thumbnail + title).
+     */
+    export function itemCellRenderer(params: { data?: ContentItem }): HTMLElement | string {
+      if (!params.data) return '';
+
+      const container = document.createElement('div');
+      container.style.display = 'flex';
+      container.style.alignItems = 'center';
+      container.style.gap = '8px';
+      container.style.height = '100%';
+
+      const videoId = extractVideoIdFromUrl(params.data.url);
+      if (videoId) {
+        const img = document.createElement('img');
+        img.src = `https://i.ytimg.com/vi/${videoId}/default.jpg`;
+        img.alt = '';
+        img.style.width = '40px';
+        img.style.height = '30px';
+        img.style.objectFit = 'cover';
+        img.style.borderRadius = '2px';
+        img.style.flexShrink = '0';
+        container.appendChild(img);
+      }
+
+      const textEl = document.createElement('span');
+      textEl.style.overflow = 'hidden';
+      textEl.style.textOverflow = 'ellipsis';
+      textEl.style.whiteSpace = 'nowrap';
+      if (params.data.url) {
+        const a = document.createElement('a');
+        a.href = params.data.url;
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.className = 'text-primary hover:underline';
+        a.textContent = params.data.name;
+        a.title = params.data.name;  // Full title on hover
+        textEl.appendChild(a);
+      } else {
+        textEl.textContent = params.data.name;
+        textEl.title = params.data.name;
+      }
+      container.appendChild(textEl);
+
+      return container;
+    }
+    ```
+
+    **5. Add YouTube icon cell renderer for Type column:**
+    ```typescript
+    /**
+     * AG Grid cell renderer for Type column (YouTube icon).
+     */
+    export function typeCellRenderer(params: { data?: ContentItem }): HTMLElement | string {
+      if (!params.data) return '';
+      if (params.data.contentType === 'YOUTUBE') {
+        const span = document.createElement('span');
+        span.title = 'YouTube';
+        span.textContent = '\u25B6'; // Play triangle as simple icon
+        span.style.color = '#FF0000';
+        span.style.fontSize = '16px';
+        return span;
+      }
+      return params.data.contentType;
+    }
+    ```
+
+    Note: Import the `ContentItem` type from content.ts in formatting.ts, or define the interface locally if circular dependency is a concern.
+
+    **6. Add tests for new formatting utilities** — In `formatting.test.ts`, add tests for:
+    - `formatCount`: null -> '--', 500 -> '500', 1234 -> '1.2K', 1234567 -> '1.2M'
+    - `formatPublishDate`: null -> '--', valid ISO -> formatted date
+    - `formatTags`: null -> '--', empty -> '--', ['a', 'b'] -> 'a, b'
+    - `truncateDescription`: null -> '--', short -> as-is, long -> truncated with ...
+  </action>
+  <verify>
+    - `cd perspectize-fe && pnpm run check` passes type checking
+    - `cd perspectize-fe && pnpm run test:run` passes all tests including new formatting tests
+    - `grep "channelTitle" perspective-fe/src/lib/queries/content.ts` shows new fields in query
+    - `grep "formatCount" perspective-fe/src/lib/utils/formatting.ts` shows new utility
+  </verify>
+  <done>
+    LIST_CONTENT query requests all new YouTube fields. ContentItem interface exported. Formatting utilities for counts, dates, tags, descriptions. Item cell renderer with thumbnail + title. Type cell renderer with YouTube icon. All new utilities tested.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Rewrite ActivityTable with server-side pagination, new columns, and page layout</name>
+  <files>
+    perspective-fe/src/lib/components/ActivityTable.svelte
+    perspective-fe/src/routes/+page.svelte
+    perspective-fe/src/app.css
+    perspective-fe/tests/components/ActivityTable.test.ts
+  </files>
+  <action>
+    **IMPORTANT ARCHITECTURE DECISION:** AG Grid's Server-Side Row Model (SSRM) requires an Enterprise license. This project uses AG Grid Community. Therefore, implement server-side data operations using AG Grid Client-Side Row Model with **manual pagination controls** outside the grid. The pattern:
+
+    1. AG Grid renders ONE page of data at a time (Client-Side Row Model)
+    2. Custom pagination controls below the grid (prev/next buttons, page size selector, total count display)
+    3. Sorting is handled by catching AG Grid's `onSortChanged` event and re-fetching from the server
+    4. Filtering is handled by catching AG Grid's `onFilterChanged` event and re-fetching from the server
+    5. Each interaction triggers a new GraphQL query with the appropriate parameters
+
+    This avoids the SSRM license issue AND the cursor-offset pagination mismatch pitfall from the research.
+
+    **1. Rewrite `ActivityTable.svelte`:**
+
+    The component manages its own data fetching. It no longer receives `rowData` as a prop.
+
+    ```svelte
+    <script lang="ts">
+      import AgGridSvelte5Component from 'ag-grid-svelte5';
+      import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+      import { themeQuartz } from '@ag-grid-community/theming';
+      import type { GridApi, GridOptions, SortChangedEvent, FilterChangedEvent, ColDef } from '@ag-grid-community/core';
+      import { graphqlClient } from '$lib/queries/client';
+      import { LIST_CONTENT, type ContentItem, type ContentResponse } from '$lib/queries/content';
+      import {
+        formatDuration, formatDate, formatCount, formatPublishDate,
+        formatTags, truncateDescription, itemCellRenderer, typeCellRenderer,
+        contentRowId
+      } from '$lib/utils/formatting';
+
+      // Pagination state
+      let pageSize = $state(10);
+      let currentPage = $state(0);
+      let totalCount = $state<number | null>(null);
+      let cursors = $state<(string | null)[]>([null]); // cursor for each page start
+      let hasNextPage = $state(false);
+      let hasPreviousPage = $state(false);
+
+      // Sort state
+      let sortField = $state<string>('UPDATED_AT');
+      let sortDirection = $state<string>('DESC');
+
+      // Filter state
+      let filterModel = $state<Record<string, any>>({});
+
+      // Data state
+      let rowData = $state<ContentItem[]>([]);
+      let loading = $state(true);
+      let gridApi = $state<GridApi | null>(null);
+
+      const modules = [ClientSideRowModelModule];
+
+      const theme = themeQuartz.withParams({
+        fontFamily: "'Geist', system-ui, sans-serif",
+        fontSize: 13,
+        headerBackgroundColor: '#1a365d',
+        headerTextColor: '#ffffff',
+        headerFontWeight: 600,
+        oddRowBackgroundColor: '#f7fafc',
+        rowHoverColor: 'rgba(26, 54, 93, 0.06)',
+        borderColor: '#d4d4d4',
+        accentColor: '#1a365d',
+        foregroundColor: '#171717',
+        backgroundColor: '#ffffff',
+        selectedRowBackgroundColor: 'rgba(26, 54, 93, 0.08)',
+        columnHoverColor: 'rgba(26, 54, 93, 0.04)',
+        headerColumnResizeHandleColor: 'rgba(255, 255, 255, 0.5)',
+        rowHeight: 44,  // Compact rows
+        headerHeight: 40,
+      });
+
+      // Column mapping from AG Grid colId to GraphQL ContentSortBy
+      const SORT_FIELD_MAP: Record<string, string> = {
+        name: 'NAME',
+        createdAt: 'CREATED_AT',
+        updatedAt: 'UPDATED_AT',
+        viewCount: 'VIEW_COUNT',
+        likeCount: 'LIKE_COUNT',
+        publishedAt: 'PUBLISHED_AT',
+      };
+
+      // Default visible columns (6)
+      const defaultColumns: ColDef[] = [
+        {
+          field: 'name',
+          headerName: 'Item',
+          flex: 2,
+          minWidth: 200,
+          sortable: true,
+          floatingFilter: true,
+          filter: 'agTextColumnFilter',
+          filterParams: { debounceMs: 500 },
+          cellRenderer: itemCellRenderer,
+          headerTooltip: 'Video title and thumbnail (from YouTube API — source data)',
+        },
+        {
+          field: 'contentType',
+          headerName: 'Type',
+          width: 70,
+          sortable: false,
+          cellRenderer: typeCellRenderer,
+          headerTooltip: 'Content type (from YouTube API — source data)',
+        },
+        {
+          field: 'length',
+          headerName: 'Length',
+          width: 90,
+          sortable: false,
+          valueGetter: (params) => {
+            if (!params.data) return '--';
+            return formatDuration(params.data.length, params.data.lengthUnits);
+          },
+          headerTooltip: 'Video duration (from YouTube API — source data)',
+          tooltipValueGetter: () => 'Duration in minutes:seconds',
+        },
+        {
+          field: 'viewCount',
+          headerName: 'Views',
+          width: 90,
+          sortable: true,
+          floatingFilter: true,
+          filter: 'agNumberColumnFilter',
+          filterParams: { debounceMs: 500 },
+          valueFormatter: (params) => formatCount(params.value),
+          headerTooltip: 'View count (from YouTube API — source data, read-only)',
+        },
+        {
+          field: 'likeCount',
+          headerName: 'Likes',
+          width: 80,
+          sortable: true,
+          floatingFilter: true,
+          filter: 'agNumberColumnFilter',
+          filterParams: { debounceMs: 500 },
+          valueFormatter: (params) => formatCount(params.value),
+          headerTooltip: 'Like count (from YouTube API — source data, read-only)',
+        },
+        {
+          field: 'publishedAt',
+          headerName: 'Date',
+          width: 110,
+          sortable: true,
+          valueFormatter: (params) => formatPublishDate(params.value),
+          headerTooltip: 'YouTube publish date (from YouTube API — source data)',
+        },
+      ];
+
+      // Hidden columns (available via column menu)
+      const hiddenColumns: ColDef[] = [
+        {
+          field: 'channelTitle',
+          headerName: 'Channel',
+          width: 140,
+          sortable: false,
+          hide: true,
+          headerTooltip: 'YouTube channel name (from YouTube API — source data)',
+        },
+        {
+          field: 'createdAt',
+          headerName: 'Date Added',
+          width: 110,
+          sortable: true,
+          hide: true,
+          valueFormatter: (params) => formatDate(params.value),
+          headerTooltip: 'Date added to Perspectize (database record)',
+        },
+        {
+          field: 'updatedAt',
+          headerName: 'Date Updated',
+          width: 110,
+          sortable: true,
+          sort: 'desc',
+          hide: true,
+          valueFormatter: (params) => formatDate(params.value),
+          headerTooltip: 'Last updated in Perspectize (database record)',
+        },
+        {
+          field: 'tags',
+          headerName: 'Tags',
+          width: 160,
+          sortable: false,
+          hide: true,
+          valueFormatter: (params) => formatTags(params.value),
+          headerTooltip: 'YouTube video tags (from YouTube API — source data)',
+        },
+        {
+          field: 'description',
+          headerName: 'Description',
+          width: 200,
+          sortable: false,
+          hide: true,
+          valueFormatter: (params) => truncateDescription(params.value),
+          tooltipValueGetter: (params) => params.data?.description || '',
+          headerTooltip: 'Video description (from YouTube API — source data)',
+        },
+      ];
+
+      const gridOptions: GridOptions<ContentItem> = {
+        columnDefs: [...defaultColumns, ...hiddenColumns],
+        pagination: false, // We handle pagination manually
+        defaultColDef: {
+          resizable: true,
+          sortable: false,
+          menuTabs: ['columnsMenuTab'], // Right-click shows column chooser
+        },
+        tooltipShowDelay: 300,
+        getRowId: contentRowId,
+        domLayout: 'normal', // CRITICAL: must be 'normal' for sticky headers
+        suppressCellFocus: true,
+        overlayNoRowsTemplate: '<span class="text-muted-foreground text-sm">No items yet - add the first one!</span>',
+        onGridReady: (params) => {
+          gridApi = params.api;
+          fetchData();
+        },
+        onSortChanged: handleSortChanged,
+        onFilterChanged: handleFilterChanged,
+      };
+
+      function handleSortChanged(event: SortChangedEvent) {
+        const sortModel = event.api.getColumnState()
+          .filter(col => col.sort)
+          .map(col => ({ colId: col.colId, sort: col.sort }));
+
+        if (sortModel.length > 0) {
+          const mapped = SORT_FIELD_MAP[sortModel[0].colId!];
+          if (mapped) {
+            sortField = mapped;
+            sortDirection = sortModel[0].sort === 'asc' ? 'ASC' : 'DESC';
+          }
+        } else {
+          sortField = 'UPDATED_AT';
+          sortDirection = 'DESC';
+        }
+
+        // Reset to first page on sort change
+        currentPage = 0;
+        cursors = [null];
+        fetchData();
+      }
+
+      function handleFilterChanged(event: FilterChangedEvent) {
+        const model = event.api.getFilterModel();
+        filterModel = model || {};
+
+        // Reset to first page on filter change
+        currentPage = 0;
+        cursors = [null];
+        fetchData();
+      }
+
+      function buildFilter(): Record<string, any> | undefined {
+        const filter: Record<string, any> = {};
+        let hasFilter = false;
+
+        // Text search from name column floating filter
+        if (filterModel.name?.filter) {
+          filter.search = filterModel.name.filter;
+          hasFilter = true;
+        }
+
+        // Number filters for viewCount and likeCount
+        // Note: the backend ContentFilter doesn't support number range filters
+        // on viewCount/likeCount yet. For now, only the search filter is wired.
+        // viewCount/likeCount floating filters will show but won't filter server-side
+        // until the backend is extended. This is acceptable for Phase 3.2.
+
+        return hasFilter ? filter : undefined;
+      }
+
+      async function fetchData() {
+        loading = true;
+        if (gridApi) {
+          gridApi.showLoadingOverlay();
+        }
+
+        try {
+          const variables: Record<string, any> = {
+            first: pageSize,
+            sortBy: sortField,
+            sortOrder: sortDirection,
+            includeTotalCount: true,
+          };
+
+          // Add cursor for non-first pages
+          const cursor = cursors[currentPage];
+          if (cursor) {
+            variables.after = cursor;
+          }
+
+          // Add filter
+          const filter = buildFilter();
+          if (filter) {
+            variables.filter = filter;
+          }
+
+          const data = await graphqlClient.request<ContentResponse>(LIST_CONTENT, variables);
+          rowData = data.content.items;
+          totalCount = data.content.totalCount;
+          hasNextPage = data.content.pageInfo.hasNextPage;
+          hasPreviousPage = currentPage > 0;
+
+          // Store cursor for next page
+          if (data.content.pageInfo.endCursor && hasNextPage) {
+            cursors[currentPage + 1] = data.content.pageInfo.endCursor;
+          }
+
+          if (gridApi) {
+            if (rowData.length === 0) {
+              gridApi.showNoRowsOverlay();
+            } else {
+              gridApi.hideOverlay();
+            }
+          }
+        } catch (err) {
+          console.error('Failed to fetch content:', err);
+          rowData = [];
+          if (gridApi) {
+            gridApi.showNoRowsOverlay();
+          }
+        } finally {
+          loading = false;
+        }
+      }
+
+      function goToNextPage() {
+        if (!hasNextPage) return;
+        currentPage += 1;
+        fetchData();
+      }
+
+      function goToPreviousPage() {
+        if (currentPage === 0) return;
+        currentPage -= 1;
+        fetchData();
+      }
+
+      function changePageSize(newSize: number) {
+        pageSize = newSize;
+        currentPage = 0;
+        cursors = [null];
+        fetchData();
+      }
+
+      // Derived values
+      let totalPages = $derived(totalCount ? Math.ceil(totalCount / pageSize) : 0);
+      let startItem = $derived(currentPage * pageSize + 1);
+      let endItem = $derived(Math.min((currentPage + 1) * pageSize, totalCount ?? 0));
+    </script>
+
+    <div class="flex flex-col" style="height: calc(100vh - 4rem - 4rem);">
+      <!-- AG Grid fills available space -->
+      <div class="flex-1 min-h-0">
+        <AgGridSvelte5Component {gridOptions} {rowData} {theme} {modules} style="width: 100%; height: 100%;" />
+      </div>
+
+      <!-- Custom pagination controls -->
+      <div class="flex items-center justify-between border-t border-border px-4 py-2 text-sm text-muted-foreground bg-background">
+        <div class="flex items-center gap-2">
+          <span>Rows per page:</span>
+          <select
+            class="border border-input rounded px-2 py-1 text-sm bg-background"
+            value={pageSize}
+            onchange={(e) => changePageSize(Number((e.target as HTMLSelectElement).value))}
+          >
+            <option value={10}>10</option>
+            <option value={25}>25</option>
+            <option value={50}>50</option>
+          </select>
+        </div>
+
+        <div class="flex items-center gap-4">
+          {#if totalCount !== null}
+            <span>{startItem}-{endItem} of {totalCount.toLocaleString()}</span>
+          {/if}
+          <div class="flex gap-1">
+            <button
+              onclick={goToPreviousPage}
+              disabled={currentPage === 0}
+              class="px-2 py-1 border border-input rounded hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Previous page"
+            >
+              &larr;
+            </button>
+            <button
+              onclick={goToNextPage}
+              disabled={!hasNextPage}
+              class="px-2 py-1 border border-input rounded hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed"
+              aria-label="Next page"
+            >
+              &rarr;
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    ```
+
+    CRITICAL IMPLEMENTATION NOTES:
+    - `domLayout: 'normal'` (NOT 'autoHeight') so AG Grid creates its own scroll container for sticky column headers
+    - Grid height set via flex container: `calc(100vh - 4rem - 4rem)` accounts for page header (h-16 = 4rem) and Activity heading area (~4rem)
+    - Pagination is manual (buttons + GraphQL cursor pagination), not AG Grid built-in pagination
+    - AG Grid sorts trigger re-fetch, not client-side sorting
+    - `menuTabs: ['columnsMenuTab']` enables right-click column chooser for showing/hiding columns
+    - `rowHeight: 44` and `headerHeight: 40` in theme params for compact rows
+    - All column header tooltips follow the provenance pattern: "[field name] (from [source] -- [tier])"
+
+    **2. Simplify `+page.svelte`:**
+    The Activity page no longer manages data fetching -- ActivityTable does it internally.
+
+    ```svelte
+    <script lang="ts">
+      import ActivityTable from '$lib/components/ActivityTable.svelte';
+    </script>
+
+    <div class="flex flex-col h-[calc(100vh-4rem)]">
+      <!-- Activity heading -->
+      <div class="px-4 md:px-6 lg:px-8 py-3 flex items-center justify-between">
+        <h1 class="text-2xl font-bold">Activity</h1>
+      </div>
+
+      <!-- Table fills remaining space -->
+      <div class="flex-1 min-h-0 px-4 md:px-6 lg:px-8 pb-2">
+        <ActivityTable />
+      </div>
+    </div>
+    ```
+
+    Key changes from current +page.svelte:
+    - REMOVED: PageWrapper (no longer needed -- the page manages its own layout for maximum table real estate)
+    - REMOVED: Global search input
+    - REMOVED: Subtitle "Recently updated content"
+    - REMOVED: Content query and data fetching (moved into ActivityTable)
+    - REMOVED: Error/loading states (handled inside ActivityTable)
+    - ActivityTable now takes NO props (it manages its own data)
+    - Full-height layout: heading + table fills viewport
+
+    **3. Update `app.css`** — Add styles for AG Grid floating filter rows if needed. The floating filters add an extra row below column headers. They should inherit the grid's theme. No additional CSS should be needed since `themeQuartz` handles floating filter styling, but verify the filter inputs look clean with the navy header theme.
+
+    **4. Update `ActivityTable.test.ts`** — The test needs to be updated since ActivityTable no longer accepts `rowData`, `loading`, or `searchText` props. The component now fetches data internally. Update tests to:
+    - Mock `graphqlClient.request` to return sample data
+    - Test that component renders without errors
+    - Test that it creates an AG Grid instance
+    - Keep test structure simple since the complex interactions (sort, filter, paginate) require full browser testing
+
+    **5. Run test coverage gate:**
+    ```bash
+    cd perspectize-fe && pnpm run test:coverage
+    ```
+  </action>
+  <verify>
+    - `cd perspectize-fe && pnpm run check` passes type checking
+    - `cd perspective-fe && pnpm run test:coverage` exits 0 (80% stmts/lines/functions, 75% branches)
+    - `cd perspectize-fe && pnpm run dev` -- Activity page loads with new columns
+    - Column headers are sticky (scroll down, headers stay)
+    - Clicking a sortable column header re-fetches data from server (check Network tab)
+    - Page size selector (10/25/50) re-fetches with correct size
+    - Prev/Next buttons navigate between pages via cursor pagination
+    - Total count is displayed
+    - Floating filter on "Item" column triggers server-side text search
+    - Right-click column header shows column chooser
+    - Empty database shows "No items yet - add the first one!"
+    - Hovering a column header shows provenance tooltip
+  </verify>
+  <done>
+    ActivityTable completely rewritten with: server-side sort (GraphQL sort params sent on column click), server-side pagination (cursor-based, one page at a time, manual controls), per-column floating filters, 6 default visible columns with YouTube data, 5 hidden columns with column chooser, compact 44px rows, sticky headers (domLayout='normal'), empty state overlay, data provenance tooltips on all column headers. Activity page simplified to heading + full-height table.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `cd perspective-fe && pnpm run check` — type checking passes
+- `cd perspective-fe && pnpm run test:coverage` — coverage gate passes
+- Server-side sorting: column click -> Network tab shows new GraphQL query with sortBy/sortOrder
+- Server-side pagination: Next/Prev buttons -> new GraphQL query with after cursor
+- Floating filters: type in filter -> debounced GraphQL query with filter param
+- 6 columns visible by default, 5 hidden and available via right-click column menu
+- Compact rows (~44px), sticky column headers
+- Empty state displays "No items yet - add the first one!"
+- Column header tooltips show data provenance information
+</verification>
+
+<success_criteria>
+- Server-side sorting works for all sortable columns (name, views, likes, date, created, updated)
+- Server-side pagination fetches one page at a time with total count
+- Per-column floating filters (text on name, number on views/likes)
+- 6 default columns: Item (thumbnail+title), Type (icon), Length, Views, Likes, Date
+- 5 hidden columns: Channel, Date Added, Date Updated, Tags, Description
+- Right-click column header shows column chooser
+- Compact rows ~44px height
+- Sticky page header + sticky AG Grid headers
+- Empty state message in table body
+- Provenance tooltips on every column header
+- Frontend tests pass with 80%+ coverage
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03.2-activity-page-beta-quality/03.2-03-SUMMARY.md`
+</output>

--- a/.planning/phases/03.2-activity-page-beta-quality/03.2-04-PLAN.md
+++ b/.planning/phases/03.2-activity-page-beta-quality/03.2-04-PLAN.md
@@ -1,0 +1,220 @@
+---
+phase: 03.2-activity-page-beta-quality
+plan: 04
+type: execute
+wave: 3
+depends_on: ["03.2-02", "03.2-03"]
+files_modified:
+  - perspectize-fe/src/routes/+page.svelte
+  - perspective-fe/src/lib/components/ActivityTable.svelte
+  - perspectize-fe/src/routes/+layout.svelte
+  - perspectize-fe/tests/components/Header.test.ts
+  - perspectize-fe/tests/components/ActivityTable.test.ts
+autonomous: false
+
+must_haves:
+  truths:
+    - "Activity page renders with heading, popover button in header, and full-height table"
+    - "Column chooser button or right-click menu allows showing/hiding columns"
+    - "All 11 success criteria from ROADMAP are satisfied in the integrated page"
+    - "Frontend and backend test coverage gates pass"
+  artifacts:
+    - path: "perspectize-fe/src/routes/+page.svelte"
+      provides: "Integrated Activity page with heading, no subtitle, no global search"
+      contains: "ActivityTable"
+    - path: "perspective-fe/src/lib/components/ActivityTable.svelte"
+      provides: "Final polished table with all features integrated"
+      min_lines: 100
+  key_links:
+    - from: "perspectize-fe/src/lib/components/Header.svelte"
+      to: "perspectize-fe/src/lib/components/AddVideoPopover.svelte"
+      via: "import and render"
+      pattern: "AddVideoPopover"
+    - from: "perspectize-fe/src/routes/+page.svelte"
+      to: "perspectize-fe/src/lib/components/ActivityTable.svelte"
+      via: "import and render"
+      pattern: "ActivityTable"
+---
+
+<objective>
+Integration pass: polish the Activity page by connecting the popover dialog, table, and layout together, fix any rough edges, and verify all 11 success criteria.
+
+Purpose: Plans 01-03 built the individual pieces (backend fields, popover dialog, table rewrite). This plan ensures they work together correctly -- the popover triggers from the header, the table loads server-side data, the layout fits correctly, and any integration issues are resolved.
+
+Output: Fully integrated Activity page that meets all 11 success criteria from the roadmap. Visual checkpoint for user verification.
+</objective>
+
+<execution_context>
+@/Users/jamesjordan/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/jamesjordan/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-CONTEXT.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-01-SUMMARY.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-02-SUMMARY.md
+@.planning/phases/03.2-activity-page-beta-quality/03.2-03-SUMMARY.md
+@perspectize-fe/CLAUDE.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Integration polish and test coverage</name>
+  <files>
+    perspective-fe/src/routes/+page.svelte
+    perspective-fe/src/lib/components/ActivityTable.svelte
+    perspective-fe/src/routes/+layout.svelte
+    perspective-fe/tests/components/Header.test.ts
+    perspective-fe/tests/components/ActivityTable.test.ts
+  </files>
+  <action>
+    **1. Verify layout integration** — Ensure the page header (Header.svelte in +layout.svelte) stays sticky at `top-0 z-50`, and the Activity page content below it uses `h-[calc(100vh-4rem)]` to fill remaining height. The AG Grid inside ActivityTable should have its own scroll container (domLayout='normal') so column headers stick while data scrolls.
+
+    If the layout isn't working correctly (double scroll bars, content not filling viewport, headers not sticky), fix:
+    - `+layout.svelte`: Ensure the main content area doesn't add its own scroll. Remove any `overflow-auto` on the main container.
+    - `+page.svelte`: Ensure `h-[calc(100vh-4rem)]` correctly accounts for the 4rem (h-16) header.
+    - `ActivityTable.svelte`: Ensure the grid container uses `flex-1 min-h-0` to fill available space without overflowing.
+
+    **2. Verify popover + table interaction** — Test that:
+    - Add Video popover opens from the header button
+    - While popover is open, the table is still scrollable/clickable
+    - After adding a video, the table refetches and shows the new item
+    - The popover's `queryClient.invalidateQueries({ queryKey: ['content'] })` triggers a refetch. But since ActivityTable now uses `graphqlClient.request` directly (not TanStack Query), the invalidation won't work automatically. Fix this by either:
+      - (a) Having ActivityTable use TanStack Query internally (preferred -- keeps cache consistency), OR
+      - (b) Dispatching a custom event from AddVideoPopover that ActivityTable listens to for refetch
+
+    **Option (a) is preferred.** Modify ActivityTable to use TanStack Query for data fetching:
+    ```svelte
+    const contentQuery = createQuery(() => ({
+      queryKey: ['content', { page: currentPage, pageSize, sortField, sortDirection, filter: buildFilter() }],
+      queryFn: () => graphqlClient.request<ContentResponse>(LIST_CONTENT, {
+        first: pageSize,
+        after: cursors[currentPage] || undefined,
+        sortBy: sortField,
+        sortOrder: sortDirection,
+        includeTotalCount: true,
+        filter: buildFilter(),
+      }),
+      staleTime: 30_000, // 30 seconds
+    }));
+    ```
+    Then derive rowData from query result:
+    ```svelte
+    let rowData = $derived(contentQuery.data?.content.items ?? []);
+    ```
+    And update pagination state from query result via $effect.
+
+    IMPORTANT: If switching to TanStack Query complicates the reactive fetching (since sort/filter/page changes need to re-trigger the query), AND the functional wrapper pattern already handles this (the query re-runs when reactive dependencies in the queryKey change), then this approach is clean. But cursor management gets tricky because `cursors[currentPage]` must be stable.
+
+    Alternative simpler approach: Keep the manual `fetchData()` function but add a way for AddVideoPopover to signal a refetch. Since the popover already calls `queryClient.invalidateQueries({ queryKey: ['content'] })`, have ActivityTable ALSO use TanStack Query so the invalidation propagates. This is the right call.
+
+    **3. Ensure test coverage meets gates** — After integration changes, run:
+    ```bash
+    cd perspectize-fe && pnpm run test:coverage
+    ```
+    If coverage drops due to new untested code paths (pagination controls, sort handlers, filter handlers), add targeted tests. Focus on:
+    - Formatting utilities (already tested in Plan 03)
+    - Component rendering (mocked GraphQL client)
+    - Don't try to test AG Grid interactions in jsdom (they require real DOM)
+
+    **4. Run backend tests:**
+    ```bash
+    cd perspectize-go && make test
+    ```
+
+    **5. Fix any type errors:**
+    ```bash
+    cd perspective-fe && pnpm run check
+    ```
+  </action>
+  <verify>
+    - `cd perspective-fe && pnpm run check` passes
+    - `cd perspectize-fe && pnpm run test:coverage` exits 0
+    - `cd perspectize-go && make test` passes
+    - Dev server loads Activity page without errors
+    - Adding a video via popover causes the table to show the new item
+  </verify>
+  <done>
+    Activity page fully integrated: header popover, table with server-side ops, layout with sticky headers and full-height table, all working together. Test coverage gates pass for both frontend and backend.
+  </done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>
+    Complete Activity page beta quality rebuild:
+    1. Server-side sorting (click column headers)
+    2. Per-column floating filters (type in filter inputs below headers)
+    3. Server-side pagination (prev/next buttons, page size selector)
+    4. 6 default columns: Item (thumbnail+title), Type (YouTube icon), Length, Views, Likes, Date
+    5. Hidden columns via right-click column header: Channel, Date Added, Date Updated, Tags, Description
+    6. Compact rows (~44px)
+    7. Sticky page header + sticky table headers
+    8. Add Video as popover (not modal) -- page stays interactive
+    9. Data provenance tooltips on column headers
+    10. Empty state message
+    11. YouTube metadata fields exposed through GraphQL
+  </what-built>
+  <how-to-verify>
+    Start both servers:
+    ```bash
+    cd perspectize-go && make run &
+    cd perspectize-fe && pnpm run dev
+    ```
+    Open http://localhost:5173 in browser.
+
+    **Verify these 11 success criteria:**
+
+    1. **Server-side sorting:** Click "Views" column header. Check Network tab -- should see GraphQL request with `sortBy: "VIEW_COUNT"`. Data should reorder. Click again for DESC.
+
+    2. **Per-column filters:** Look for filter input below the "Item" column header. Type a few characters. After 500ms debounce, Network tab should show a new query with filter.search parameter.
+
+    3. **Server-side pagination:** Look at bottom pagination bar. Shows "1-10 of N". Click right arrow. Network tab should show query with `after` cursor. Page size dropdown: change to 25, verify 25 rows load.
+
+    4. **6 default columns:** Verify you see: Item (with small thumbnail), Type (red play icon), Length, Views, Likes, Date.
+
+    5. **Column chooser:** Right-click any column header. Select "Columns" tab. Check/uncheck "Channel" -- it should appear/disappear. Also try Date Added, Tags, Description.
+
+    6. **New YouTube fields:** Views should show numbers like "1.2K" or "45.3K". Likes similar. Date should show YouTube publish date (not database date). Hover column headers to see tooltips.
+
+    7. **Compact rows:** Rows should be ~44px height. Thumbnails small (~40x30px).
+
+    8. **Sticky headers:** Scroll down in the table. Both the app header ("Perspectize" logo bar) and the AG Grid column headers should stay fixed.
+
+    9. **Add Video popover:** Click "Add Video" button. A popover should appear near the button (not a centered modal). The table behind it should still be scrollable/clickable. Paste a YouTube URL and submit -- should show success toast and table updates.
+
+    10. **Data provenance tooltips:** Hover over any column header. Tooltip should say something like "View count (from YouTube API -- source data, read-only)".
+
+    11. **Empty state:** If you have no data, the table should show "No items yet - add the first one!" in the grid area.
+
+    **Also check:**
+    - No console errors
+    - Page loads quickly (no loading all 100 items upfront)
+    - Mobile: resize to 375px -- table should still be usable (no P1 regressions)
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe specific issues to fix</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- All 11 roadmap success criteria verified by human
+- `cd perspective-fe && pnpm run check && pnpm run test:coverage` passes
+- `cd perspectize-go && make test` passes
+- No console errors in browser
+- No visual regressions at 375px
+</verification>
+
+<success_criteria>
+- Human confirms all 11 success criteria from ROADMAP are met
+- Frontend and backend test coverage gates pass
+- No console errors
+- No mobile regressions
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03.2-activity-page-beta-quality/03.2-04-SUMMARY.md`
+</output>

--- a/.planning/phases/03.2-activity-page-beta-quality/03.2-RESEARCH.md
+++ b/.planning/phases/03.2-activity-page-beta-quality/03.2-RESEARCH.md
@@ -1,0 +1,550 @@
+# Phase 3.2: Activity Page Beta Quality - Research
+
+**Researched:** 2026-02-12
+**Domain:** AG Grid server-side operations, SvelteKit/Svelte 5, GraphQL pagination/filtering, popover UI patterns
+**Confidence:** HIGH
+
+## Summary
+
+This phase rebuilds the Activity page table on top of the design token system from Phase 3.1, implementing server-side data operations (sorting/filtering/pagination), exposing new YouTube metadata columns, and replacing the modal dialog with a non-modal popover pattern.
+
+**Key findings:**
+- AG Grid Server-Side Row Model (SSRM) requires implementing an IServerSideDatasource with a getRows() callback that receives request parameters (startRow, endRow, sortModel, filterModel) and returns data via success() callback.
+- The GraphQL schema already includes viewCount and likeCount fields, but the backend YouTube adapter doesn't extract them from the API response. Additional fields (channelTitle, publishedAt, tags) exist in the YouTube API response but aren't surfaced.
+- shadcn-svelte provides a Popover component built on bits-ui primitives, using Floating UI for positioning. The pattern is non-modal by default and supports anchoring to trigger elements.
+- AG Grid provides built-in floating filters, column chooser via tool panel or column menu, sticky headers by default, and customizable overlays for empty/loading states.
+
+**Primary recommendation:** Use AG Grid SSRM with GraphQL cursor-based pagination (already implemented in the schema). Extend backend YouTube adapter to extract statistics and snippet fields from the existing API response (no new API calls needed). Use shadcn-svelte Popover with Floating UI for the dialog redesign.
+
+## Standard Stack
+
+The established libraries/tools for this domain:
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| AG Grid v32.2.x | 32.2.1 | Data grid with SSRM | Industry standard for complex data grids, built-in server-side operations, column management, floating filters |
+| ag-grid-svelte5 | 1.0.3 | Svelte 5 wrapper | Official Svelte 5 adapter, bundles AG Grid internally |
+| @tanstack/svelte-query | 6.0.18 | Data fetching | Established pattern in codebase, handles GraphQL queries reactively |
+| shadcn-svelte | latest | UI primitives | Established in codebase, includes Popover component |
+| bits-ui | 2.15.5 | Headless components | Powers shadcn-svelte, provides accessible primitives |
+| Floating UI | (via bits-ui) | Popover positioning | Industry standard for floating element positioning |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| graphql-request | 7.4.0 | GraphQL client | Already used for mutations/queries |
+| svelte-sonner | 1.0.7 | Toast notifications | Already used for feedback |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| SSRM | Client-Side Row Model with infinite scroll | SSRM is more appropriate for true server-side operations; client-side would require fetching all data upfront |
+| Floating UI | Manual positioning | Floating UI handles edge cases (viewport boundaries, scroll containers) that manual positioning misses |
+| shadcn Popover | bits-ui Popover directly | shadcn provides styled components matching the design system |
+
+**Installation:**
+```bash
+# Already installed — no new dependencies needed
+# AG Grid packages already pinned to 32.2.x
+# shadcn Popover can be added via CLI if not present:
+pnpm dlx shadcn-svelte@latest add popover
+```
+
+## Architecture Patterns
+
+### Recommended Project Structure
+```
+perspectize-fe/src/
+├── routes/
+│   └── (dashboard)/
+│       └── activity/
+│           ├── +page.svelte           # Activity page container
+│           ├── ActivityTable.svelte   # AG Grid wrapper with SSRM
+│           ├── AddVideoPopover.svelte # Non-modal popover dialog
+│           └── columns.ts             # Column definitions with filters/tooltips
+├── lib/
+│   ├── queries/
+│   │   └── content.ts                 # GraphQL query with pagination args
+│   └── components/shadcn/popover/     # shadcn Popover components
+```
+
+### Pattern 1: AG Grid Server-Side Datasource
+**What:** Implement IServerSideDatasource to delegate sorting/filtering/pagination to GraphQL backend
+**When to use:** Whenever you need to display large datasets with server-controlled operations
+
+**Example:**
+```typescript
+// Source: https://www.ag-grid.com/javascript-data-grid/server-side-model-datasource/
+import type { IServerSideDatasource, IServerSideGetRowsParams } from '@ag-grid-community/core';
+
+const datasource: IServerSideDatasource = {
+  getRows(params: IServerSideGetRowsParams) {
+    const { request, success, fail } = params;
+    const { startRow, endRow, sortModel, filterModel } = request;
+
+    // Calculate pagination args
+    const pageSize = endRow - startRow;
+
+    // Transform sortModel to GraphQL args
+    const sortBy = sortModel[0]?.colId || 'CREATED_AT';
+    const sortOrder = sortModel[0]?.sort === 'asc' ? 'ASC' : 'DESC';
+
+    // Transform filterModel to GraphQL filter input
+    const filter = buildFilterFromModel(filterModel);
+
+    // Query GraphQL
+    graphqlClient.request(CONTENT_QUERY, {
+      first: pageSize,
+      after: encodeCursor(startRow),
+      sortBy,
+      sortOrder,
+      filter,
+      includeTotalCount: true
+    })
+    .then(response => {
+      success({
+        rowData: response.content.items,
+        rowCount: response.content.totalCount // enables "last page" button
+      });
+    })
+    .catch(error => {
+      console.error('Failed to fetch rows:', error);
+      fail();
+    });
+  }
+};
+
+// Apply to grid
+gridOptions.serverSideDatasource = datasource;
+gridOptions.rowModelType = 'serverSide';
+gridOptions.cacheBlockSize = 25; // matches page size
+```
+
+### Pattern 2: Floating Filters Per-Column
+**What:** Enable per-column filters in the header row instead of global search
+**When to use:** When columns have different data types requiring different filter UIs
+
+**Example:**
+```typescript
+// Source: https://www.ag-grid.com/javascript-data-grid/floating-filters/
+const columnDefs = [
+  {
+    field: 'name',
+    headerName: 'Title',
+    floatingFilter: true,
+    filter: 'agTextColumnFilter',
+    filterParams: {
+      debounceMs: 500
+    }
+  },
+  {
+    field: 'viewCount',
+    headerName: '# Views',
+    floatingFilter: true,
+    filter: 'agNumberColumnFilter'
+  },
+  {
+    field: 'createdAt',
+    headerName: 'Date',
+    floatingFilter: true,
+    filter: 'agDateColumnFilter'
+  }
+];
+```
+
+### Pattern 3: Non-Modal Popover with Floating UI
+**What:** Use shadcn Popover for dialogs that don't block page interaction
+**When to use:** When users might want to reference page content while filling a form
+
+**Example:**
+```svelte
+<!-- Source: https://www.shadcn-svelte.com/docs/components/popover -->
+<script lang="ts">
+  import * as Popover from "$lib/components/shadcn/popover";
+  import Button from "$lib/components/shadcn/button/button.svelte";
+  import Input from "$lib/components/shadcn/input/input.svelte";
+
+  let url = $state('');
+  let open = $state(false);
+
+  function handleSubmit() {
+    // Mutation logic
+    open = false;
+  }
+</script>
+
+<Popover.Root bind:open>
+  <Popover.Trigger asChild let:builder>
+    <Button builders={[builder]}>Add Video</Button>
+  </Popover.Trigger>
+  <Popover.Content class="w-80" sideOffset={8} align="end">
+    <form onsubmit={handleSubmit}>
+      <Input
+        type="url"
+        bind:value={url}
+        autocomplete="off"
+        placeholder="YouTube URL"
+      />
+      <Button type="submit">Submit</Button>
+    </form>
+  </Popover.Content>
+</Popover.Root>
+```
+
+### Pattern 4: Column Header Tooltips
+**What:** Display data provenance information on column header hover
+**When to use:** To explain what data source a column comes from
+
+**Example:**
+```typescript
+// Source: https://www.ag-grid.com/javascript-data-grid/tooltips/
+const columnDefs = [
+  {
+    field: 'viewCount',
+    headerName: '# Views',
+    headerTooltip: 'View count from YouTube API (source data, read-only)'
+  },
+  {
+    field: 'createdAt',
+    headerName: 'Date Added',
+    headerTooltip: 'Date this video was added to Perspectize (database)'
+  }
+];
+```
+
+### Anti-Patterns to Avoid
+- **Don't mix client-side and server-side row models** — Pick one row model type and stick with it. Switching between them causes state inconsistencies.
+- **Don't forget cacheBlockSize** — Must match your page size or SSRM will make redundant requests.
+- **Don't use OFFSET pagination with cursor-based GraphQL** — AG Grid's startRow/endRow must be converted to cursor values, not used directly as OFFSET.
+- **Don't create modal overlays for non-modal popovers** — Use Popover.Root without Popover.Overlay or Popover.Portal to prevent background darkening.
+
+## Don't Hand-Roll
+
+Problems that look simple but have existing solutions:
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Floating element positioning | Manual absolute positioning with offsets | Floating UI (via bits-ui/shadcn) | Handles viewport boundaries, scroll containers, flipping, collision detection |
+| Empty state overlays | Custom "no data" div overlaid on grid | AG Grid `overlayNoRowsTemplate` | Integrated with grid lifecycle, auto-shows/hides, supports custom components |
+| Column visibility management | Custom checkbox list for show/hide | AG Grid Columns Tool Panel or Column Menu | Built-in, keyboard accessible, drag-to-reorder, searchable |
+| Filter UI components | Custom input fields synced to state | AG Grid floating filters | Type-appropriate (text/number/date), debounced, integrated with SSRM |
+| Cursor pagination logic | Manual base64 encode/decode | Relay cursor connection pattern (already in backend schema) | Opaque cursors, standardized PageInfo, hasNextPage/hasPreviousPage |
+| Sort/filter state management | Manual state tracking for sort direction, active filters | AG Grid SSRM request object | Grid manages state, passes changes via sortModel/filterModel |
+
+**Key insight:** AG Grid SSRM was designed for exactly this use case. Don't fight the framework by rebuilding its features. Implementing IServerSideDatasource is the only custom code needed — everything else is configuration.
+
+## Common Pitfalls
+
+### Pitfall 1: OFFSET vs Cursor Pagination Mismatch
+**What goes wrong:** AG Grid SSRM sends startRow/endRow (OFFSET-style), but GraphQL uses cursor-based pagination (first/after).
+**Why it happens:** The two pagination styles don't map 1:1. startRow=50 doesn't mean "skip 50 rows" with cursors.
+**How to avoid:** Convert startRow to a cursor. For example, if startRow=50, encode cursor as `base64("cursor:50")` and pass as `after` argument. Maintain a cursor cache or use deterministic cursor encoding based on sort order.
+**Warning signs:** Duplicate rows appear when paginating, or rows are skipped entirely.
+
+### Pitfall 2: Forgetting includeTotalCount for Last Page Detection
+**What goes wrong:** Pagination controls show "Next" button even on the last page because AG Grid doesn't know the total row count.
+**Why it happens:** GraphQL query doesn't request `totalCount`, so AG Grid can't determine when to stop.
+**How to avoid:** Always include `includeTotalCount: true` in SSRM queries and pass `rowCount` in the success() callback.
+**Warning signs:** Clicking "Next" on the last page makes empty API requests.
+
+### Pitfall 3: Not Debouncing Filter Changes
+**What goes wrong:** Every keystroke in a filter input triggers a GraphQL query, causing network spam and poor UX.
+**Why it happens:** Default filter behavior is immediate.
+**How to avoid:** Set `filterParams: { debounceMs: 500 }` on text column filters.
+**Warning signs:** Network tab shows dozens of identical queries as user types.
+
+### Pitfall 4: Browser Autocomplete Fighting URL Input
+**What goes wrong:** Browser suggests previously pasted URLs in the "Add Video" input, even though user doesn't want these suggestions.
+**Why it happens:** Modern browsers aggressively autocomplete URL fields.
+**How to avoid:** Set `autocomplete="off"` on the input. For extra protection, consider `autocomplete="new-url"` or a non-standard value. Note: Some browsers ignore autocomplete="off" on password/username fields, but URL fields usually respect it.
+**Warning signs:** Users complain about unwanted suggestions appearing in the input.
+
+### Pitfall 5: Missing YouTube Fields in Backend Response
+**What goes wrong:** GraphQL query returns null for viewCount, likeCount, publishedAt, channelTitle, or tags even though the data exists.
+**Why it happens:** The YouTube adapter fetches these fields from the API but doesn't extract them into the Content domain model. They're only stored in the raw `response` JSON field.
+**How to avoid:** Update the YouTube adapter's `GetVideoMetadata()` to extract statistics.viewCount, statistics.likeCount, statistics.commentCount, snippet.channelTitle, snippet.publishedAt, and snippet.tags into the VideoMetadata struct. Update the domain model to include these fields.
+**Warning signs:** GraphQL playground shows null for new columns, but inspecting the `response` JSON shows the data is present.
+
+### Pitfall 6: Sticky Header Conflicts with domLayout="autoHeight"
+**What goes wrong:** Column headers scroll with the table body instead of staying fixed at the top.
+**Why it happens:** domLayout="autoHeight" disables AG Grid's internal scrolling container.
+**How to avoid:** Use domLayout="normal" (default) with an explicit grid height. The grid creates its own scroll container, which enables sticky headers. Combine with a page-level sticky header for the Activity heading.
+**Warning signs:** Headers disappear when scrolling down the table.
+
+## Code Examples
+
+Verified patterns from official sources:
+
+### Server-Side Datasource with GraphQL
+```typescript
+// Source: https://www.ag-grid.com/javascript-data-grid/server-side-model-datasource/
+// Adapted for GraphQL cursor pagination
+
+import type { IServerSideDatasource, IServerSideGetRowsParams } from '@ag-grid-community/core';
+import { graphqlClient } from '$lib/queries/client';
+import { gql } from 'graphql-request';
+
+const CONTENT_QUERY = gql`
+  query ContentList(
+    $first: Int
+    $after: String
+    $sortBy: ContentSortBy
+    $sortOrder: SortOrder
+    $filter: ContentFilter
+    $includeTotalCount: Boolean
+  ) {
+    content(
+      first: $first
+      after: $after
+      sortBy: $sortBy
+      sortOrder: $sortOrder
+      filter: $filter
+      includeTotalCount: $includeTotalCount
+    ) {
+      items {
+        id
+        name
+        url
+        length
+        viewCount
+        likeCount
+        createdAt
+        updatedAt
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+`;
+
+function createServerSideDatasource(): IServerSideDatasource {
+  return {
+    getRows(params: IServerSideGetRowsParams) {
+      const { request, success, fail } = params;
+      const { startRow, endRow, sortModel, filterModel } = request;
+
+      const pageSize = endRow - startRow;
+
+      // Convert AG Grid sortModel to GraphQL args
+      const sortBy = sortModel[0]?.colId?.toUpperCase() || 'CREATED_AT';
+      const sortOrder = sortModel[0]?.sort?.toUpperCase() || 'DESC';
+
+      // Convert startRow to cursor
+      // Simple approach: encode row index (more sophisticated: maintain cursor cache)
+      const after = startRow > 0 ? btoa(`cursor:${startRow - 1}`) : undefined;
+
+      // Convert filterModel to GraphQL filter
+      const filter = buildGraphQLFilter(filterModel);
+
+      graphqlClient.request(CONTENT_QUERY, {
+        first: pageSize,
+        after,
+        sortBy,
+        sortOrder,
+        filter,
+        includeTotalCount: true
+      })
+      .then(response => {
+        success({
+          rowData: response.content.items,
+          rowCount: response.content.totalCount // CRITICAL: enables last page detection
+        });
+      })
+      .catch(error => {
+        console.error('Server-side datasource error:', error);
+        fail();
+      });
+    }
+  };
+}
+
+function buildGraphQLFilter(filterModel: any): any {
+  // Transform AG Grid filterModel to GraphQL ContentFilter input
+  // Example: { name: { type: 'contains', filter: 'example' } }
+  //       -> { search: 'example' }
+  // Implement based on your GraphQL schema's filter capabilities
+  return {};
+}
+```
+
+### Floating Filters Configuration
+```typescript
+// Source: https://www.ag-grid.com/javascript-data-grid/floating-filters/
+
+import type { ColDef } from '@ag-grid-community/core';
+
+const columnDefs: ColDef[] = [
+  {
+    field: 'name',
+    headerName: 'Item',
+    floatingFilter: true,
+    filter: 'agTextColumnFilter',
+    filterParams: {
+      debounceMs: 500,
+      buttons: ['reset', 'apply']
+    }
+  },
+  {
+    field: 'viewCount',
+    headerName: '# Views',
+    floatingFilter: true,
+    filter: 'agNumberColumnFilter',
+    filterParams: {
+      debounceMs: 500
+    }
+  },
+  {
+    field: 'createdAt',
+    headerName: 'Date',
+    floatingFilter: true,
+    filter: 'agDateColumnFilter'
+  }
+];
+```
+
+### Custom Empty State Overlay
+```typescript
+// Source: https://www.ag-grid.com/javascript-data-grid/overlays/
+
+const gridOptions = {
+  overlayNoRowsTemplate: '<span>No items yet - add the first one!</span>',
+  // Alternative: custom component
+  // noRowsOverlayComponent: CustomNoRowsOverlay
+};
+```
+
+### shadcn Popover with Click-Outside Dismiss
+```svelte
+<!-- Source: https://www.shadcn-svelte.com/docs/components/popover -->
+<script lang="ts">
+  import * as Popover from "$lib/components/shadcn/popover";
+  import Button from "$lib/components/shadcn/button/button.svelte";
+  import Input from "$lib/components/shadcn/input/input.svelte";
+  import Label from "$lib/components/shadcn/label/label.svelte";
+
+  let url = $state('');
+  let open = $state(false);
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault();
+    // Mutation logic
+    open = false; // Close on success
+  }
+</script>
+
+<Popover.Root bind:open>
+  <Popover.Trigger asChild let:builder>
+    <Button builders={[builder]} variant="default">
+      Add Video
+    </Button>
+  </Popover.Trigger>
+  <Popover.Content
+    class="w-80"
+    sideOffset={8}
+    align="end"
+  >
+    <!-- No Popover.Overlay — page stays interactive -->
+    <!-- Click-outside dismiss is default behavior -->
+    <form onsubmit={handleSubmit}>
+      <div class="grid gap-4">
+        <Label for="url">YouTube URL</Label>
+        <Input
+          id="url"
+          type="url"
+          bind:value={url}
+          autocomplete="off"
+          placeholder="https://youtube.com/watch?v=..."
+        />
+        <div class="flex justify-end gap-2">
+          <Button type="button" variant="secondary" onclick={() => open = false}>
+            Cancel
+          </Button>
+          <Button type="submit">
+            Add
+          </Button>
+        </div>
+      </div>
+    </form>
+  </Popover.Content>
+</Popover.Root>
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Client-side pagination (fetch all, paginate locally) | Server-side pagination with SSRM | AG Grid SSRM introduced ~2017 | Scales to millions of rows, reduces initial load time |
+| Global search bar | Per-column floating filters | AG Grid added floating filters in v18 (2017) | More precise filtering, type-appropriate UIs |
+| Modal dialogs for forms | Non-modal popovers | Popover API baseline 2024, Floating UI v1 2021 | Less disruptive UX, users can reference page content |
+| OFFSET pagination | Cursor-based pagination (Relay spec) | Relay connection spec published 2015 | Stable pagination with concurrent updates, opaque cursors |
+| Manual column show/hide UI | AG Grid Columns Tool Panel | Built-in since early versions | Accessible, searchable, drag-to-reorder |
+
+**Deprecated/outdated:**
+- `on:click` event syntax in Svelte 5 — use `onclick` attribute
+- `export let` for props in Svelte 5 — use `$props()` rune
+- `$: reactive statements` in Svelte 5 — use `$derived()` or `$effect()`
+- `autocomplete="false"` — use `autocomplete="off"` (string "false" is not a valid value)
+
+## Open Questions
+
+Things that couldn't be fully resolved:
+
+1. **Cursor encoding strategy for AG Grid startRow**
+   - What we know: AG Grid sends startRow (integer offset), GraphQL expects cursor (opaque string)
+   - What's unclear: Should we maintain a cursor cache, or use deterministic encoding based on sort field + row index?
+   - Recommendation: Start with deterministic encoding (`btoa("cursor:{id}")`) since the backend already uses ID-based cursors. If sort order changes break pagination, implement a cursor cache.
+
+2. **Filter capabilities of ContentFilter input**
+   - What we know: GraphQL schema has a ContentFilter input with contentType and length range filters
+   - What's unclear: Does it support text search on name/description? Multi-column filters?
+   - Recommendation: Check backend ContentFilter implementation. May need to extend it to support per-column text filters. Alternatively, use floating filters only for columns that map to existing filter fields, disable for others in Phase 3.2.
+
+3. **YouTube API publishedAt vs database createdAt**
+   - What we know: User wants "Date" column to show YouTube publish date, not Perspectize database date
+   - What's unclear: Does the YouTube API always return publishedAt? Is it nullable?
+   - Recommendation: Verify YouTube API response structure. If publishedAt is always present, extract it. If nullable, fall back to database createdAt with a visual indicator (tooltip showing which date is displayed).
+
+4. **Column chooser placement — header or toolbar?**
+   - What we know: User requested "column chooser button near the heading or as a toolbar element"
+   - What's unclear: Exact placement preference
+   - Recommendation: Place near "Activity" heading as a secondary button (outlined/ghost variant). AG Grid Tool Panel is an alternative but requires a sidebar, which may not fit the "maximize table real estate" goal.
+
+## Sources
+
+### Primary (HIGH confidence)
+- [AG Grid Server-Side Row Model](https://www.ag-grid.com/javascript-data-grid/server-side-model/) - SSRM architecture and concepts
+- [AG Grid SSRM Datasource](https://www.ag-grid.com/javascript-data-grid/server-side-model-datasource/) - IServerSideDatasource interface, getRows() parameters
+- [AG Grid SSRM Pagination](https://www.ag-grid.com/javascript-data-grid/server-side-model-pagination/) - Pagination configuration, lastRowIndex for total count
+- [AG Grid Floating Filters](https://www.ag-grid.com/javascript-data-grid/floating-filters/) - Per-column filter configuration, floating filter types
+- [AG Grid Column Menu](https://www.ag-grid.com/javascript-data-grid/column-menu/) - Right-click column header menu
+- [AG Grid Columns Tool Panel](https://www.ag-grid.com/javascript-data-grid/tool-panel-columns/) - Column chooser sidebar
+- [AG Grid Tooltips](https://www.ag-grid.com/javascript-data-grid/tooltips/) - Header tooltips, cell tooltips, custom components
+- [AG Grid Overlays](https://www.ag-grid.com/javascript-data-grid/overlays/) - Empty state and loading overlays
+- [shadcn-svelte Popover](https://www.shadcn-svelte.com/docs/components/popover) - Popover component structure, usage with Svelte 5
+- [Floating UI Popover](https://floating-ui.com/docs/popover) - Positioning, click-outside dismiss, accessibility
+- [Relay GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm) - Connection, Edge, PageInfo structure
+- [YouTube Data API Videos](https://developers.google.com/youtube/v3/docs/videos) - Video resource structure, snippet and statistics fields
+- [MDN autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete) - Preventing browser autofill
+
+### Secondary (MEDIUM confidence)
+- [GraphQL Filtering, Pagination & Sorting Tutorial](https://www.howtographql.com/graphql-js/8-filtering-pagination-and-sorting/) - Best practices for filter/sort arguments
+- [Medium: YouTube Data API v3 — Fetch View Counts](https://medium.com/code-uncomplicated/youtube-data-api-v3-fetch-view-counts-thumbnails-and-more-73df8b44b5a0) - Example response structure
+
+### Tertiary (LOW confidence)
+- WebSearch results for AG Grid sticky headers (GitHub issues) - Indicates domLayout="autoHeight" conflicts with sticky headers, but not verified in official docs
+- Community discussions on autocomplete="off" effectiveness - Modern browsers may ignore it, but URL fields usually respect it
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH - All libraries verified as already installed and in use
+- Architecture: HIGH - Official AG Grid docs, official shadcn-svelte docs, verified codebase patterns
+- Pitfalls: MEDIUM - Cursor pagination mismatch inferred from AG Grid docs + GraphQL schema, not tested
+- YouTube fields: HIGH - Backend schema and YouTube adapter code inspected directly, YouTube API docs verified
+
+**Research date:** 2026-02-12
+**Valid until:** 30 days (stable technologies, AG Grid v32 established, Svelte 5 stable)


### PR DESCRIPTION
## Summary
- Research and plan Phase 3.2: Activity Page Beta Quality
- 4 execution plans across 3 waves (backend, popover, table rewrite, integration)
- Verified by gsd-plan-checker — all 11 success criteria covered

## Problem
Phase 3.2 needs planning before execution. The Activity page requires a full rebuild: server-side sorting/filtering/pagination, new YouTube columns, popover dialog, and data provenance infrastructure.

## Solution
Created comprehensive GSD planning artifacts:
- **03.2-RESEARCH.md** — AG Grid SSRM patterns, shadcn Popover, cursor pagination, YouTube field extraction
- **03.2-01-PLAN.md** (Wave 1) — Backend: expose YouTube fields + extend GraphQL sort/filter
- **03.2-02-PLAN.md** (Wave 1) — Frontend: replace modal with non-modal popover
- **03.2-03-PLAN.md** (Wave 2) — Frontend: ActivityTable rewrite with server-side ops, 11 columns
- **03.2-04-PLAN.md** (Wave 3) — Integration polish + visual verification checkpoint

## Technical Changes
- Updated ROADMAP.md with Phase 3.2 details, success criteria, and plan references
- Key architecture decision: AG Grid Client-Side Row Model with manual server-side pagination (avoids Enterprise license requirement for SSRM)

## Testing
- [x] Plans verified by gsd-plan-checker (all dimensions passed)
- [ ] Plans not yet executed — this PR is planning only

## Checklist
- [x] Follows project conventions
- [x] Planning artifacts complete
- [x] No code changes (planning docs only)

## Related Issues
Phase 3.2 in roadmap — depends on Phase 3.1 (Design Token System)

🤖 Generated with [Claude Code](https://claude.com/claude-code)