### PR TITLE
feat: redesign perspective input modal

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -25,6 +25,17 @@ frontend/src/
 └── app.html             # HTML shell
 ```
 
+## shadcn-svelte Components
+
+Components live in `src/lib/components/shadcn/` (not `ui/`). The `components.json` alias is configured correctly, but the CLI sometimes ignores it. After installing a new component, verify it landed in `shadcn/` — if it went to `ui/`, move it and remove the empty `ui/` directory. Always add new components to the barrel export in `shadcn/index.ts`.
+
+```bash
+# Install from frontend/ directory
+npx shadcn-svelte@latest add <component> --yes
+# Verify location
+ls src/lib/components/shadcn/<component>/
+```
+
 ## Tailwind v4
 
 Tailwind v4 uses `--color-*` prefix for theme variables (e.g., `--color-primary`), not bare `--primary` from v3/shadcn conventions.

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -8,6 +8,7 @@
 	},
 	"aliases": {
 		"components": "$lib/components/shadcn",
+		"ui": "$lib/components/shadcn",
 		"utils": "$lib/utils"
 	}
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.2.2",
 		"typescript": "^5.9.3",
+		"vaul-svelte": "1.0.0-next.7",
 		"vite": "^7.3.1",
 		"vitest": "^4.0.18",
 		"vitest-browser-svelte": "^2.0.2"
@@ -63,6 +64,10 @@
 		"@capacitor/haptics": "^8.0.1",
 		"@tanstack/svelte-form": "^1.28.5",
 		"@tanstack/svelte-query": "^6.1.8",
+		"@tiptap/core": "^3.22.5",
+		"@tiptap/extension-placeholder": "^3.22.5",
+		"@tiptap/extension-underline": "^3.22.5",
+		"@tiptap/starter-kit": "^3.22.5",
 		"ag-grid-svelte5": "^1.0.3",
 		"clsx": "^2.1.1",
 		"graphql": "^16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
 		"@tiptap/starter-kit": "^3.22.5",
 		"ag-grid-svelte5": "^1.0.3",
 		"clsx": "^2.1.1",
+		"dompurify": "^3.4.1",
 		"graphql": "^16.13.1",
 		"graphql-request": "^7.4.0",
 		"svelte-clerk": "^1.0.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,6 +37,18 @@ importers:
       '@tanstack/svelte-query':
         specifier: ^6.1.8
         version: 6.1.8(svelte@5.53.7)
+      '@tiptap/core':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/extension-placeholder':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-underline':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/starter-kit':
+        specifier: ^3.22.5
+        version: 3.22.5
       ag-grid-svelte5:
         specifier: ^1.0.3
         version: 1.0.3
@@ -140,6 +152,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vaul-svelte:
+        specifier: 1.0.0-next.7
+        version: 1.0.0-next.7(svelte@5.53.7)
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)
@@ -1442,6 +1457,137 @@ packages:
       vitest:
         optional: true
 
+  '@tiptap/core@3.22.5':
+    resolution: {integrity: sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==}
+    peerDependencies:
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-blockquote@3.22.5':
+    resolution: {integrity: sha512-ajyP5W8fG5Hrru47T/eF3xMKOpNvWofgNJqBTeNuGl02sYxsy9a4EunyFxudsaZP9WW3VOD4SaIWr5+MqpbnOQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-bold@3.22.5':
+    resolution: {integrity: sha512-l/uDtpJISiFFyfctvnODNWBN/XPZI1jVZRacTRDDnSn8+x6KQ7G2qgFYueU7KvVJGDFVT39Iio56mcFRG/Pozg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-bullet-list@3.22.5':
+    resolution: {integrity: sha512-cf54fG9AybU8NgPMv1TOcoqAkELeRc/VpnSCt/rIJZphWQx9nsFmrtkrlCatrIcCaGtNZYwlHlMnC5LVVMu0uA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-code-block@3.22.5':
+    resolution: {integrity: sha512-d123kCfLdJTi4fue1m0+TNFztDkmIRSZGZmGu6H9KqwG5Q7IzjT9o8lzRsz+pXxYqHvqgYmXoEpM6srbzXx/Ag==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-code@3.22.5':
+    resolution: {integrity: sha512-mwDNOJC9rYbDu/JcqrN4dbUQRklJU8Fuk2raxD/IvFw9qUIcPCmxQ2XT9UTKmZz/Ju7Kdy72fss6XpgWv6gLAQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-document@3.22.5':
+    resolution: {integrity: sha512-8NJERd+pCtvSuEP4C4WMGYmRRCV12ePZL7bC+QUdFlbdXg+kNZS0zZ7hh879tYA0Kidbi8rWWD1Tx+H2ezkmMw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-dropcursor@3.22.5':
+    resolution: {integrity: sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-gapcursor@3.22.5':
+    resolution: {integrity: sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg==}
+    peerDependencies:
+      '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-hard-break@3.22.5':
+    resolution: {integrity: sha512-n0R2mUVYZU2AVbJhg/WcY9+zx690wVwvsItHJf0DrYbf1tCYHx+PRHUt/AoXk6u8BSmnkb8/FDziS8m3mjfpSg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-heading@3.22.5':
+    resolution: {integrity: sha512-hjyEG4947PAhMBfP1G6B0QAh6+y9mp2C5BQmNjprA05/lQzDAT7KFZzNh8ZVp3ol6aICKq/N1gFOW9Dc/9FUOw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-horizontal-rule@3.22.5':
+    resolution: {integrity: sha512-vUV0/ugIbXOc8SJib0h8UMhgcqZXWu/dkEhlswZN4VVven1o5enkfxEiDw+OyIJHi5rUkrdhsQ/KTxG/Xb7X8A==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-italic@3.22.5':
+    resolution: {integrity: sha512-4T8baSiLkeIymTgEwirxDFt5YgYofkP3m1+MGYdGy2HKcOK+1vpvlPhEO1X5qtZngtJW5S4+njKjinRg52A4PA==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-link@3.22.5':
+    resolution: {integrity: sha512-d671MvF3GPKoS2OVxjIlQ7hIE7MS3hREdR+d4cvnnoiLLD+ZJ6KgDnxmWqF0a1s4qxLWK2KxKRSOIfYGE31QWQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-list-item@3.22.5':
+    resolution: {integrity: sha512-W7uTmyKLhlsvuTPLv+8WwnsY+mlikBFIoLSvVcBaFt4MwpsZ+DeB6KQg02Y7tbtaAnG7rXu9Fvw2QORh2P728A==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-list-keymap@3.22.5':
+    resolution: {integrity: sha512-cGUnxJ0y515e1bVHNjUmbx7oWHoEon59w6BA5N2KwV9iW2mZZchlTX4yxJSOX+ixeVRChsa7YwC3Z1jUZ6AMEg==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-list@3.22.5':
+    resolution: {integrity: sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-ordered-list@3.22.5':
+    resolution: {integrity: sha512-OXdh4k4CNrukwiSdWdEQ49uvgnqvR0Z9aNSP4HI5/kZQ/Te1NtRtYCpUrzWyO/7CtjcCisXHti0o9C/TV8YMbQ==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-paragraph@3.22.5':
+    resolution: {integrity: sha512-52KCto4+XKpnBWpIufspWLyq4UWxAWC72ANPdGuIhbi72NRTabiTbTVN40uwGSPkyakeESG0/vKdWJCVvB4f0g==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-placeholder@3.22.5':
+    resolution: {integrity: sha512-MZAohQ3FCS763BkhGXgaWRya6WruZjwRwEAkXP8vkxbERzl2OJRjniS4uXCWzAlRb3ttE103SnY7LMdM8FvsXw==}
+    peerDependencies:
+      '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-strike@3.22.5':
+    resolution: {integrity: sha512-42WrrFK5gOom/0znH85x12Mw5IQ/6O6DWdyUWoRIrNA/qJpuHtU8oVU+bIgU2tuomMGHruRjIzgBQv5sBjEtww==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-text@3.22.5':
+    resolution: {integrity: sha512-bzpDOdAEo1JeoVZDIyV0oY0jGXkEG+AzF70SzHoRSjOvFDtKWunyXf9eO1OnOr2/fmMcckT2qwUBNBMQplWBzw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-underline@3.22.5':
+    resolution: {integrity: sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extensions@3.22.5':
+    resolution: {integrity: sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/pm@3.22.5':
+    resolution: {integrity: sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==}
+
+  '@tiptap/starter-kit@3.22.5':
+    resolution: {integrity: sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2494,6 +2640,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -2633,6 +2782,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2730,6 +2882,42 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.8:
+    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
   pug-attrs@3.0.0:
     resolution: {integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==}
@@ -2848,8 +3036,16 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
+    peerDependencies:
+      svelte: ^5.7.0
 
   runed@0.28.0:
     resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
@@ -3094,6 +3290,12 @@ packages:
     peerDependencies:
       svelte: ^5.30.2
 
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
+
   svelte@5.53.7:
     resolution: {integrity: sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==}
     engines: {node: '>=18'}
@@ -3272,6 +3474,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vaul-svelte@1.0.0-next.7:
+    resolution: {integrity: sha512-7zN7Bi3dFQixvvbUJY9uGDe7Ws/dGZeBQR2pXdXmzQiakjrxBvWo0QrmsX3HK+VH+SZOltz378cmgmCS9f9rSg==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
+
   vite-plugin-pwa@1.2.0:
     resolution: {integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==}
     engines: {node: '>=16.0.0'}
@@ -3375,6 +3583,9 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4904,6 +5115,150 @@ snapshots:
       vite: 7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)
       vitest: 4.0.18(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.46.0)
 
+  '@tiptap/core@3.22.5(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-blockquote@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-bold@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-bullet-list@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-code-block@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-code@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-document@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-dropcursor@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-gapcursor@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-hard-break@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-heading@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-horizontal-rule@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-italic@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-link@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-list-keymap@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-ordered-list@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-paragraph@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-placeholder@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-strike@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-text@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-underline@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/pm@3.22.5':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  '@tiptap/starter-kit@3.22.5':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/extension-blockquote': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-bold': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-bullet-list': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-code': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-code-block': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-document': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-dropcursor': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-gapcursor': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-hard-break': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-heading': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-horizontal-rule': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-italic': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-link': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-list-item': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-list-keymap': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-ordered-list': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-paragraph': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-strike': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-text': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-underline': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
   '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
@@ -6033,6 +6388,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkifyjs@4.3.2: {}
+
   locate-character@3.0.0: {}
 
   lodash.debounce@4.0.8: {}
@@ -6164,6 +6521,8 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  orderedmap@2.1.1: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -6248,6 +6607,75 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rope-sequence: 1.3.4
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.8:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
 
   pug-attrs@3.0.0:
     dependencies:
@@ -6431,9 +6859,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
+  rope-sequence@1.3.4: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  runed@0.23.4(svelte@5.53.7):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.53.7
 
   runed@0.28.0(svelte@5.53.7):
     dependencies:
@@ -6716,6 +7151,13 @@ snapshots:
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
+  svelte-toolbelt@0.7.1(svelte@5.53.7):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.23.4(svelte@5.53.7)
+      style-to-object: 1.0.14
+      svelte: 5.53.7
+
   svelte@5.53.7:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6897,6 +7339,12 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vaul-svelte@1.0.0-next.7(svelte@5.53.7):
+    dependencies:
+      runed: 0.23.4(svelte@5.53.7)
+      svelte: 5.53.7
+      svelte-toolbelt: 0.7.1(svelte@5.53.7)
+
   vite-plugin-pwa@1.2.0(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
@@ -6973,6 +7421,8 @@ snapshots:
       - yaml
 
   void-elements@3.1.0: {}
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dompurify:
+        specifier: ^3.4.1
+        version: 3.4.1
       graphql:
         specifier: ^16.13.1
         version: 16.13.1
@@ -2015,6 +2018,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5703,6 +5709,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/frontend/src/lib/components/AddFieldSearch.svelte
+++ b/frontend/src/lib/components/AddFieldSearch.svelte
@@ -1,0 +1,195 @@
+<script lang="ts" module>
+	/**
+	 * TODO: Backend integration needed for:
+	 * - Persisting custom field definitions
+	 * - Loading user's custom fields from API
+	 * - Syncing available fields with backend schema
+	 */
+	export type FieldDef = {
+		key: string;
+		label: string;
+		kind: string;
+		existing: boolean;
+		desc?: string;
+		custom?: boolean;
+	};
+</script>
+
+<script lang="ts">
+	import XIcon from '@lucide/svelte/icons/x';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import PlusIcon from '@lucide/svelte/icons/plus';
+
+	const AVAILABLE_FIELDS: FieldDef[] = [
+		{ key: 'quality', label: 'Quality', kind: 'rating', existing: true, desc: 'How well made is this?' },
+		{ key: 'agreement', label: 'Agreement', kind: 'rating', existing: true, desc: 'Do you agree with it?' },
+		{ key: 'importance', label: 'Importance', kind: 'rating', existing: true, desc: 'How much does this matter?' },
+		{ key: 'confidence', label: 'Confidence', kind: 'rating', existing: true, desc: 'How sure are you?' },
+		{ key: 'originality', label: 'Originality', kind: 'rating', existing: false, desc: 'How fresh is the take?' },
+		{ key: 'clarity', label: 'Clarity', kind: 'rating', existing: false, desc: 'Is it easy to follow?' },
+		{ key: 'depth', label: 'Depth', kind: 'rating', existing: false, desc: 'How deep does it go?' },
+		{ key: 'entertainment', label: 'Entertainment', kind: 'rating', existing: false, desc: 'How fun was it?' },
+		{ key: 'rigor', label: 'Rigor', kind: 'rating', existing: false, desc: 'Is it well-argued?' },
+		{ key: 'relevance', label: 'Relevance', kind: 'rating', existing: false, desc: 'Does it matter now?' },
+		{ key: 'bias', label: 'Bias', kind: 'rating', existing: false, desc: 'How slanted is it?' },
+		{
+			key: 'actionability',
+			label: 'Actionability',
+			kind: 'rating',
+			existing: false,
+			desc: 'Can you do something with this?',
+		},
+	];
+
+	let {
+		addedKeys,
+		onAdd,
+		placeholder = 'Add a field — e.g. clarity',
+		dense = false,
+	}: {
+		addedKeys: string[];
+		onAdd: (field: FieldDef) => void;
+		placeholder?: string;
+		dense?: boolean;
+	} = $props();
+
+	let query = $state('');
+	let isOpen = $state(false);
+	let isFocused = $state(false);
+	let wrapperEl: HTMLDivElement;
+
+	const filtered = $derived(() => {
+		const needle = query.trim().toLowerCase();
+		const available = AVAILABLE_FIELDS.filter((f) => !addedKeys.includes(f.key));
+		if (!needle) return available.slice(0, 8);
+		return available.filter((f) => f.label.toLowerCase().includes(needle) || f.key.includes(needle)).slice(0, 8);
+	});
+
+	const canCreateCustom = $derived(() => {
+		const trimmed = query.trim();
+		return trimmed.length > 0 && !filtered().some((f) => f.label.toLowerCase() === trimmed.toLowerCase());
+	});
+
+	function handleClickOutside(e: MouseEvent) {
+		if (wrapperEl && !wrapperEl.contains(e.target as Node)) {
+			isOpen = false;
+		}
+	}
+
+	function addExisting(field: FieldDef) {
+		// TODO: Log field addition for backend sync
+		console.log('[Perspectize] add field', field);
+		onAdd(field);
+		query = '';
+		isOpen = false;
+	}
+
+	function addCustom() {
+		const name = query.trim();
+		const key = `custom:${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+		const field: FieldDef = { key, label: name, kind: 'rating', existing: false, custom: true };
+		// TODO: Persist custom field definition to backend
+		console.log('[Perspectize] create custom field', field);
+		onAdd(field);
+		query = '';
+		isOpen = false;
+	}
+
+	$effect(() => {
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => document.removeEventListener('mousedown', handleClickOutside);
+	});
+</script>
+
+<div bind:this={wrapperEl} class="relative">
+	<!-- Search input -->
+	<div
+		class="flex items-center gap-2 px-3 border rounded-lg bg-background transition-shadow"
+		class:h-[34px]={dense}
+		class:h-10={!dense}
+		style="border-color: {isFocused ? 'var(--color-ring)' : 'var(--color-input)'}; box-shadow: {isFocused
+			? '0 0 0 3px color-mix(in srgb, var(--color-ring) 15%, transparent)'
+			: 'none'};"
+	>
+		<SearchIcon class="size-3.5 text-muted-foreground flex-shrink-0" />
+		<input
+			type="text"
+			bind:value={query}
+			oninput={() => {
+				isOpen = true;
+			}}
+			onfocus={() => {
+				isOpen = true;
+				isFocused = true;
+			}}
+			onblur={() => {
+				isFocused = false;
+			}}
+			{placeholder}
+			class="flex-1 border-none outline-none bg-transparent font-sans text-sm text-foreground min-w-0"
+		/>
+		{#if query}
+			<button
+				type="button"
+				onclick={() => {
+					query = '';
+				}}
+				class="border-none bg-transparent text-muted-foreground cursor-pointer p-0.5"
+				aria-label="Clear"
+			>
+				<XIcon class="size-3" />
+			</button>
+		{/if}
+	</div>
+
+	<!-- Dropdown -->
+	{#if isOpen && (filtered().length > 0 || canCreateCustom())}
+		<div
+			class="absolute top-[calc(100%+6px)] left-0 right-0 bg-popover border border-border rounded-[10px] shadow-lg p-1 z-50 max-h-[260px] overflow-y-auto"
+		>
+			{#each filtered() as field (field.key)}
+				<button
+					type="button"
+					onmousedown={(e) => e.preventDefault()}
+					onclick={() => addExisting(field)}
+					class="flex items-center justify-between w-full px-2.5 py-2 rounded-md bg-transparent border-none cursor-pointer text-left hover:bg-accent transition-colors"
+				>
+					<div class="flex flex-col gap-0.5">
+						<span class="font-sans font-medium text-[13px] text-foreground">{field.label}</span>
+						{#if field.desc}
+							<span class="font-serif text-xs text-muted-foreground">{field.desc}</span>
+						{/if}
+					</div>
+					<span
+						class="font-sans text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded font-semibold flex-shrink-0 ml-2"
+						style="background: {field.existing
+							? 'color-mix(in srgb, var(--color-primary) 10%, transparent)'
+							: 'var(--color-muted)'}; color: {field.existing
+							? 'var(--color-primary)'
+							: 'var(--color-muted-foreground)'};"
+					>
+						{field.existing ? 'existing' : 'suggested'}
+					</span>
+				</button>
+			{/each}
+
+			{#if canCreateCustom()}
+				<button
+					type="button"
+					onmousedown={(e) => e.preventDefault()}
+					onclick={addCustom}
+					class="flex items-center gap-2 w-full px-2.5 py-2 rounded-md bg-transparent border-none cursor-pointer text-left hover:bg-accent transition-colors"
+					class:border-t={filtered().length > 0}
+					class:border-border={filtered().length > 0}
+					class:mt-1={filtered().length > 0}
+					class:pt-2.5={filtered().length > 0}
+				>
+					<PlusIcon class="size-3.5 text-primary flex-shrink-0" />
+					<span class="font-sans text-[13px] text-primary font-medium">
+						Create "{query.trim()}"
+					</span>
+				</button>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/AddFieldSearch.svelte
+++ b/frontend/src/lib/components/AddFieldSearch.svelte
@@ -77,8 +77,6 @@
 	}
 
 	function addExisting(field: FieldDef) {
-		// TODO: Log field addition for backend sync
-		console.log('[Perspectize] add field', field);
 		onAdd(field);
 		query = '';
 		isOpen = false;
@@ -88,8 +86,6 @@
 		const name = query.trim();
 		const key = `custom:${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
 		const field: FieldDef = { key, label: name, kind: 'rating', existing: false, custom: true };
-		// TODO: Persist custom field definition to backend
-		console.log('[Perspectize] create custom field', field);
 		onAdd(field);
 		query = '';
 		isOpen = false;

--- a/frontend/src/lib/components/CommentEditor.svelte
+++ b/frontend/src/lib/components/CommentEditor.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { Editor } from '@tiptap/core';
+	import StarterKit from '@tiptap/starter-kit';
+	import Underline from '@tiptap/extension-underline';
+	import Placeholder from '@tiptap/extension-placeholder';
+	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
+
+	/**
+	 * CommentEditor — lightweight rich text editor using Tiptap.
+	 * Toolbar: B/I/U + bullet list + numbered list.
+	 * Optional popout button for fullscreen editing.
+	 */
+	let {
+		value = '',
+		onChange,
+		minHeight = 80,
+		placeholder = 'Anything to write about your take?',
+		showPopout = false,
+		onPopout,
+	}: {
+		value?: string;
+		onChange: (html: string) => void;
+		minHeight?: number;
+		placeholder?: string;
+		showPopout?: boolean;
+		onPopout?: () => void;
+	} = $props();
+
+	let editorElement: HTMLDivElement;
+	let editor: Editor | null = $state(null);
+
+	onMount(() => {
+		editor = new Editor({
+			element: editorElement,
+			extensions: [
+				StarterKit.configure({
+					heading: false,
+					codeBlock: false,
+					blockquote: false,
+					horizontalRule: false,
+				}),
+				Underline,
+				Placeholder.configure({ placeholder }),
+			],
+			content: value,
+			onUpdate: ({ editor: e }) => {
+				onChange(e.getHTML());
+			},
+			editorProps: {
+				attributes: {
+					class: 'tiptap-content',
+					style: `min-height: ${minHeight}px; padding: 8px 10px; outline: none; font-family: var(--font-serif); font-size: 13.5px; line-height: 1.5; color: var(--color-foreground); overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap;`,
+				},
+			},
+		});
+	});
+
+	// Sync external value changes (e.g., from fullscreen editor)
+	$effect(() => {
+		if (editor && value !== editor.getHTML()) {
+			editor.commands.setContent(value, { emitUpdate: false });
+		}
+	});
+
+	onDestroy(() => {
+		editor?.destroy();
+	});
+
+	function toolAction(command: () => void) {
+		return (e: MouseEvent) => {
+			e.preventDefault();
+			command();
+			editor?.commands.focus();
+		};
+	}
+</script>
+
+<div
+	class="comment-editor-wrapper border border-input rounded-lg bg-white overflow-hidden flex flex-col w-full min-w-0"
+>
+	<!-- Toolbar -->
+	<div class="flex items-center gap-0.5 px-1.5 py-1 border-b border-border bg-accent relative">
+		<button
+			type="button"
+			class="tool-btn font-bold"
+			class:active={editor?.isActive('bold')}
+			onmousedown={toolAction(() => editor?.chain().focus().toggleBold().run())}
+			aria-label="Bold">B</button
+		>
+		<button
+			type="button"
+			class="tool-btn italic font-serif"
+			class:active={editor?.isActive('italic')}
+			onmousedown={toolAction(() => editor?.chain().focus().toggleItalic().run())}
+			aria-label="Italic">I</button
+		>
+		<button
+			type="button"
+			class="tool-btn underline"
+			class:active={editor?.isActive('underline')}
+			onmousedown={toolAction(() => editor?.chain().focus().toggleUnderline().run())}
+			aria-label="Underline">U</button
+		>
+
+		<div class="w-px h-3.5 bg-border mx-1"></div>
+
+		<button
+			type="button"
+			class="tool-btn"
+			class:active={editor?.isActive('bulletList')}
+			onmousedown={toolAction(() => editor?.chain().focus().toggleBulletList().run())}
+			aria-label="Bullet list"
+		>
+			<svg
+				width="14"
+				height="14"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+			>
+				<line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line
+					x1="8"
+					y1="18"
+					x2="21"
+					y2="18"
+				/>
+				<circle cx="4" cy="6" r="1.2" fill="currentColor" stroke="none" /><circle
+					cx="4"
+					cy="12"
+					r="1.2"
+					fill="currentColor"
+					stroke="none"
+				/><circle cx="4" cy="18" r="1.2" fill="currentColor" stroke="none" />
+			</svg>
+		</button>
+		<button
+			type="button"
+			class="tool-btn font-mono text-[11px] font-semibold"
+			class:active={editor?.isActive('orderedList')}
+			onmousedown={toolAction(() => editor?.chain().focus().toggleOrderedList().run())}
+			aria-label="Numbered list">1.</button
+		>
+
+		{#if showPopout && onPopout}
+			<button
+				type="button"
+				class="absolute top-1.5 right-1.5 p-1 border-none bg-transparent text-muted-foreground cursor-pointer rounded hover:opacity-70"
+				onclick={onPopout}
+				aria-label="Expand comment"
+			>
+				<ExternalLinkIcon class="size-3.5" />
+			</button>
+		{/if}
+	</div>
+
+	<!-- Editor content -->
+	<div bind:this={editorElement}></div>
+</div>
+
+<style>
+	.tool-btn {
+		width: 26px;
+		height: 22px;
+		border: none;
+		background: transparent;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 12px;
+		color: var(--color-muted-foreground);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.tool-btn:hover {
+		background: var(--color-muted);
+	}
+	.tool-btn.active {
+		background: var(--color-muted);
+		color: var(--color-foreground);
+	}
+
+	/* Tiptap content styles */
+	:global(.tiptap-content ul),
+	:global(.tiptap-content ol) {
+		padding-left: 22px;
+		margin: 4px 0;
+	}
+	:global(.tiptap-content li) {
+		margin: 2px 0;
+	}
+	:global(.tiptap-content p.is-editor-empty:first-child::before) {
+		content: attr(data-placeholder);
+		color: var(--color-muted-foreground);
+		opacity: 0.7;
+		float: left;
+		height: 0;
+		pointer-events: none;
+	}
+</style>

--- a/frontend/src/lib/components/CommentFullscreen.svelte
+++ b/frontend/src/lib/components/CommentFullscreen.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import XIcon from '@lucide/svelte/icons/x';
+	import CommentEditor from './CommentEditor.svelte';
+
+	/**
+	 * CommentFullscreen — overlay for expanded comment editing.
+	 * Shares value/onChange with the inline CommentEditor.
+	 */
+	let {
+		value = '',
+		onChange,
+		onClose,
+	}: {
+		value?: string;
+		onChange: (html: string) => void;
+		onClose: () => void;
+	} = $props();
+
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) onClose();
+	}
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="fixed inset-0 bg-black/55 flex items-center justify-center p-4 z-[100]" onclick={handleBackdropClick}>
+	<div class="bg-white rounded-xl w-full max-w-[560px] max-h-[90%] flex flex-col overflow-hidden shadow-2xl">
+		<!-- Header -->
+		<div class="px-4 py-3 border-b border-border flex items-center justify-between">
+			<span class="font-sans font-semibold text-[15px]">Comment</span>
+			<button
+				type="button"
+				onclick={onClose}
+				class="border-none bg-transparent cursor-pointer p-1.5 text-muted-foreground rounded-md hover:opacity-70"
+				aria-label="Close"
+			>
+				<XIcon class="size-4" />
+			</button>
+		</div>
+		<!-- Editor -->
+		<div class="p-3.5 flex-1 overflow-auto flex">
+			<div class="flex-1 min-w-0">
+				<CommentEditor {value} {onChange} minHeight={300} />
+			</div>
+		</div>
+	</div>
+</div>

--- a/frontend/src/lib/components/PerspectivePopover.svelte
+++ b/frontend/src/lib/components/PerspectivePopover.svelte
@@ -20,6 +20,7 @@
 	import CommentEditor from '$lib/components/CommentEditor.svelte';
 	import CommentFullscreen from '$lib/components/CommentFullscreen.svelte';
 	import AddFieldSearch from '$lib/components/AddFieldSearch.svelte';
+	import { sanitizeHtml } from '$lib/utils/sanitize';
 	import type { FieldDef } from '$lib/components/AddFieldSearch.svelte';
 	import { useCreatePerspective } from '$lib/queries/hooks/useCreatePerspective';
 	import { useUpdatePerspective } from '$lib/queries/hooks/useUpdatePerspective';
@@ -183,10 +184,10 @@
 		return Object.fromEntries(entries) as Record<string, number>;
 	}
 
-	// Get review text — only send if non-empty after stripping HTML tags
+	// Get review text — sanitize HTML and only send if non-empty
 	function getReview(): string | undefined {
 		const stripped = comment.replace(/<[^>]*>/g, '').trim();
-		return stripped ? comment : undefined;
+		return stripped ? sanitizeHtml(comment) : undefined;
 	}
 
 	function handleSubmit(e: Event) {

--- a/frontend/src/lib/components/PerspectivePopover.svelte
+++ b/frontend/src/lib/components/PerspectivePopover.svelte
@@ -107,8 +107,6 @@
 				break;
 			default:
 				dynamicValues = { ...dynamicValues, [key]: val };
-				// TODO: Backend integration — persist custom field value
-				console.log('[Perspectize] dynamic field changed', key, val);
 				break;
 		}
 	}
@@ -153,10 +151,17 @@
 		confidence = existingPerspective?.confidence ?? null;
 		const l = existingPerspective?.like;
 		likeValue = l === 'THUMBS_UP' ? 'THUMBS_UP' : l === 'THUMBS_DOWN' ? 'THUMBS_DOWN' : null;
-		comment = '';
+		comment = existingPerspective?.review ?? '';
 		commentFullscreenOpen = false;
-		activeFields = [...DEFAULT_FIELDS];
-		dynamicValues = {};
+		// Restore dynamic fields from customFields if editing
+		const cf = existingPerspective?.customFields as Record<string, number> | null;
+		if (cf && Object.keys(cf).length > 0) {
+			activeFields = [...DEFAULT_FIELDS, ...Object.keys(cf)];
+			dynamicValues = { ...cf };
+		} else {
+			activeFields = [...DEFAULT_FIELDS];
+			dynamicValues = {};
+		}
 	});
 
 	const isMobile = new MediaQuery('(max-width: 639px)');
@@ -169,8 +174,19 @@
 
 	function handleCommentChange(html: string) {
 		comment = html;
-		// TODO: Backend integration — comment not yet persisted
-		console.log('[Perspectize] comment changed', html);
+	}
+
+	// Build customFields payload from dynamic (non-core) field values
+	function buildCustomFields(): Record<string, number> | undefined {
+		const entries = Object.entries(dynamicValues).filter(([, v]) => v !== null);
+		if (entries.length === 0) return undefined;
+		return Object.fromEntries(entries) as Record<string, number>;
+	}
+
+	// Get review text — only send if non-empty after stripping HTML tags
+	function getReview(): string | undefined {
+		const stripped = comment.replace(/<[^>]*>/g, '').trim();
+		return stripped ? comment : undefined;
 	}
 
 	function handleSubmit(e: Event) {
@@ -194,6 +210,8 @@
 					importance: importance ?? undefined,
 					confidence: confidence ?? undefined,
 					like: likeValue ?? undefined,
+					review: getReview(),
+					customFields: buildCustomFields(),
 				},
 				{
 					onSuccess: () => {
@@ -211,6 +229,8 @@
 					importance: importance ?? undefined,
 					confidence: confidence ?? undefined,
 					like: likeValue ?? undefined,
+					review: getReview(),
+					customFields: buildCustomFields(),
 				},
 				{
 					onSuccess: () => {

--- a/frontend/src/lib/components/PerspectivePopover.svelte
+++ b/frontend/src/lib/components/PerspectivePopover.svelte
@@ -1,31 +1,38 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
-	import ThumbsUpIcon from '@lucide/svelte/icons/thumbs-up';
-	import ThumbsDownIcon from '@lucide/svelte/icons/thumbs-down';
-	/* import PlusIcon from '@lucide/svelte/icons/plus'; */
+	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 	import InfoIcon from '@lucide/svelte/icons/info';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { MediaQuery } from 'svelte/reactivity';
 	import {
 		Dialog,
 		DialogContent,
 		DialogHeader,
 		DialogTitle,
+		Drawer,
+		DrawerContent,
+		DrawerHeader,
+		DrawerTitle,
 		Button,
 	} from '$lib/components/shadcn';
 	import RatingInput from '$lib/components/RatingInput.svelte';
+	import Thumbs from '$lib/components/Thumbs.svelte';
+	import CommentEditor from '$lib/components/CommentEditor.svelte';
+	import CommentFullscreen from '$lib/components/CommentFullscreen.svelte';
+	import AddFieldSearch from '$lib/components/AddFieldSearch.svelte';
+	import type { FieldDef } from '$lib/components/AddFieldSearch.svelte';
 	import { useCreatePerspective } from '$lib/queries/hooks/useCreatePerspective';
 	import { useUpdatePerspective } from '$lib/queries/hooks/useUpdatePerspective';
-	/* import { useCreateClaim } from '$lib/queries/hooks/useCreateClaim'; */
 	import type { PerspectiveItem } from '$lib/queries/perspectives';
 
 	/**
 	 * PerspectivePopover — centered modal for creating or editing a perspective.
 	 *
-	 * Per CONTEXT.md (Figma Make decisions):
-	 * - Always rendered as a centered Dialog (not anchored to table cell)
-	 * - No text inputs (no Review textarea, no Title input) in Phase 4
-	 * - Like field = thumbs up/down toggle buttons (THUMBS_UP / THUMBS_DOWN)
-	 * - Ratings: 2x2 grid with hasInteracted tracking, submit null if not interacted
-	 * - "+ Add More..." expansion for claim creation (claim creation is Wave 3)
+	 * Redesigned layout (Variation A):
+	 * - Header with content title (single line, truncated)
+	 * - Overall (thumbs) + Comment row directly under header
+	 * - Scrollable body: 2x2 rating grid with dynamic field adding
+	 * - Equal-width Save/Cancel buttons at bottom
 	 */
 	let {
 		contentId,
@@ -45,8 +52,7 @@
 
 	const isEditMode = $derived(existingPerspective !== null);
 
-	// Rating state — null means unset (user has not interacted).
-	// Initialize from existingPerspective for edit mode; $effect resets when it changes.
+	// --- Core rating fields (backend-mapped) ---
 	let quality = $state<number | null>(null);
 	let agreement = $state<number | null>(null);
 	let importance = $state<number | null>(null);
@@ -54,18 +60,92 @@
 
 	// Like field — 'THUMBS_UP', 'THUMBS_DOWN', or null
 	type LikeValue = 'THUMBS_UP' | 'THUMBS_DOWN' | null;
-	function parseLike(l: string | null | undefined): LikeValue {
-		if (l === 'THUMBS_UP') return 'THUMBS_UP';
-		if (l === 'THUMBS_DOWN') return 'THUMBS_DOWN';
-		return null;
-	}
 	let likeValue = $state<LikeValue>(null);
 
-	/* "+ Add More..." expansion for claim creation — TODO: Re-enable in a future phase */
-	/* let showMore = $state(false); */
-	/* let claimText = $state(''); */
+	// Comment (rich text HTML)
+	// TODO: Backend integration — comment field not yet in GraphQL schema
+	let comment = $state('');
+	let commentFullscreenOpen = $state(false);
 
-	// Reset state when existingPerspective changes (e.g., when switching rows)
+	// Dynamic fields — tracks which rating fields are shown
+	const DEFAULT_FIELDS = ['quality', 'agreement', 'importance', 'confidence'];
+	let activeFields = $state<string[]>([...DEFAULT_FIELDS]);
+
+	// Dynamic field values for non-core fields
+	// TODO: Backend integration — custom/suggested fields not yet in schema
+	let dynamicValues = $state<Record<string, number | null>>({});
+
+	// Mapping from field key to bindable state getter/setter
+	function getFieldValue(key: string): number | null {
+		switch (key) {
+			case 'quality':
+				return quality;
+			case 'agreement':
+				return agreement;
+			case 'importance':
+				return importance;
+			case 'confidence':
+				return confidence;
+			default:
+				return dynamicValues[key] ?? null;
+		}
+	}
+
+	function setFieldValue(key: string, val: number | null) {
+		switch (key) {
+			case 'quality':
+				quality = val;
+				break;
+			case 'agreement':
+				agreement = val;
+				break;
+			case 'importance':
+				importance = val;
+				break;
+			case 'confidence':
+				confidence = val;
+				break;
+			default:
+				dynamicValues = { ...dynamicValues, [key]: val };
+				// TODO: Backend integration — persist custom field value
+				console.log('[Perspectize] dynamic field changed', key, val);
+				break;
+		}
+	}
+
+	function getFieldLabel(key: string): string {
+		const labels: Record<string, string> = {
+			quality: 'Quality',
+			agreement: 'Agreement',
+			importance: 'Importance',
+			confidence: 'Confidence',
+		};
+		return (
+			labels[key] ??
+			key
+				.replace(/^custom:/, '')
+				.replace(/-/g, ' ')
+				.replace(/\b\w/g, (c) => c.toUpperCase())
+		);
+	}
+
+	function addField(field: FieldDef) {
+		if (!activeFields.includes(field.key)) {
+			activeFields = [...activeFields, field.key];
+		}
+	}
+
+	function removeField(key: string) {
+		activeFields = activeFields.filter((k) => k !== key);
+		if (!DEFAULT_FIELDS.includes(key)) {
+			const { [key]: _, ...rest } = dynamicValues;
+			dynamicValues = rest;
+		} else {
+			setFieldValue(key, null);
+		}
+	}
+
+	// Reset state when existingPerspective changes
 	$effect(() => {
 		quality = existingPerspective?.quality ?? null;
 		agreement = existingPerspective?.agreement ?? null;
@@ -73,29 +153,34 @@
 		confidence = existingPerspective?.confidence ?? null;
 		const l = existingPerspective?.like;
 		likeValue = l === 'THUMBS_UP' ? 'THUMBS_UP' : l === 'THUMBS_DOWN' ? 'THUMBS_DOWN' : null;
-		/* showMore = false; */
-		/* claimText = ''; */
+		comment = '';
+		commentFullscreenOpen = false;
+		activeFields = [...DEFAULT_FIELDS];
+		dynamicValues = {};
 	});
+
+	const isMobile = new MediaQuery('(max-width: 639px)');
 
 	const createMutation = useCreatePerspective();
 	const updateMutation = useUpdatePerspective();
-	/* const createClaimMutation = useCreateClaim(); */
-
 	const isPending = $derived(createMutation.isPending || updateMutation.isPending);
-	/* const isClaimPending = $derived(createClaimMutation.isPending); */
 
-	function toggleLike(val: 'THUMBS_UP' | 'THUMBS_DOWN') {
-		likeValue = likeValue === val ? null : val;
+	const hasComment = $derived(!!comment.replace(/<[^>]*>/g, '').trim());
+
+	function handleCommentChange(html: string) {
+		comment = html;
+		// TODO: Backend integration — comment not yet persisted
+		console.log('[Perspectize] comment changed', html);
 	}
 
 	function handleSubmit(e: Event) {
 		e.preventDefault();
 
-		// Validate: at least one field must be non-empty
 		const hasAnyRating = quality !== null || agreement !== null || importance !== null || confidence !== null;
 		const hasLike = likeValue !== null;
+		const hasDynamic = Object.values(dynamicValues).some((v) => v !== null);
 
-		if (!hasAnyRating && !hasLike) {
+		if (!hasAnyRating && !hasLike && !hasComment && !hasDynamic) {
 			toast.error('Please fill in at least one field');
 			return;
 		}
@@ -135,183 +220,227 @@
 			);
 		}
 	}
-
-	/* function handleCreateClaim() {
-		const trimmed = claimText.trim();
-		if (!trimmed) {
-			toast.error('Please enter claim text');
-			return;
-		}
-
-		createClaimMutation.mutate(
-			{
-				text: trimmed,
-				userID: userId,
-				parentContentID: contentId,
-			},
-			{
-				onSuccess: () => {
-					// Clear the claim textarea; popover stays open so user can continue their perspective
-					claimText = '';
-				},
-			},
-		);
-	} */
-
-	function handleCancel() {
-		onClose();
-	}
 </script>
 
-<Dialog
-	bind:open
-	onOpenChange={(isOpen) => {
-		if (!isOpen) onClose();
-	}}
->
-	<DialogContent
-		class="sm:max-w-sm w-[calc(100vw-2rem)] max-h-[90vh] overflow-y-auto overflow-x-hidden p-0"
-		overlayClass="bg-transparent"
-	>
-		<!-- Header -->
-		<div class="px-6 py-4 border-b border-border">
-			<DialogHeader>
-				<div class="flex items-center justify-center gap-2 mb-2">
-					<DialogTitle class="text-xl font-semibold text-center">
-						{isEditMode ? 'Edit Perspective' : 'Add Perspective'}
-					</DialogTitle>
-					<div class="relative group">
-						<button
-							type="button"
-							class="p-1 rounded-full text-muted-foreground hover:opacity-70 transition-opacity"
-							aria-label="About perspectives"
-						>
-							<InfoIcon class="size-4" />
-						</button>
-						<div
-							class="absolute left-1/2 -translate-x-1/2 top-full mt-2 px-3 py-2 rounded-lg shadow-xl text-xs w-56 text-center z-[100] bg-foreground text-background opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"
-						>
-							Add as much or as little as you like
-							<div class="absolute left-1/2 -translate-x-1/2 -top-1 w-2 h-2 rotate-45 bg-foreground"></div>
-						</div>
-					</div>
-				</div>
-				<p class="text-sm text-muted-foreground text-center text-wrap line-clamp-2 max-w-full">
-					{contentName}
-				</p>
-			</DialogHeader>
-		</div>
-
-		<!-- Form -->
-		<form onsubmit={handleSubmit} class="px-6 py-4 space-y-4">
-			<!-- Ratings 2x2 grid -->
-			<div class="px-2">
-				<div class="grid grid-cols-2 gap-4">
-					<RatingInput label="Quality" name="quality" bind:value={quality} />
-					<RatingInput label="Agreement" name="agreement" bind:value={agreement} />
-					<RatingInput label="Importance" name="importance" bind:value={importance} />
-					<RatingInput label="Confidence" name="confidence" bind:value={confidence} />
-				</div>
+{#snippet modalBody(mobile: boolean)}
+	<!-- Header -->
+	<div class="px-5 pt-4 pb-3 border-b border-border relative">
+		{#if mobile}
+			<!-- Grabber handle -->
+			<div class="flex justify-center pb-2">
+				<div class="w-9 h-1 rounded-full bg-black/[0.18]"></div>
 			</div>
-
-			<div class="border-t border-border"></div>
-
-			<!-- Like — thumbs up/down toggle -->
-			<div class="flex flex-col items-center gap-2">
-				<span class="text-xs font-medium text-muted-foreground">Like</span>
-				<div class="flex items-center justify-center gap-4">
-					<button
-						type="button"
-						onclick={() => toggleLike('THUMBS_UP')}
-						class="p-3 rounded-lg transition-all border-2"
-						class:bg-green-500={likeValue === 'THUMBS_UP'}
-						class:text-white={likeValue === 'THUMBS_UP'}
-						class:border-green-500={likeValue === 'THUMBS_UP'}
-						class:bg-muted={likeValue !== 'THUMBS_UP'}
-						class:text-muted-foreground={likeValue !== 'THUMBS_UP'}
-						class:border-transparent={likeValue !== 'THUMBS_UP'}
-						aria-label="Thumbs up"
-						aria-pressed={likeValue === 'THUMBS_UP'}
-					>
-						<ThumbsUpIcon class="size-6" strokeWidth={2} />
-					</button>
-					<button
-						type="button"
-						onclick={() => toggleLike('THUMBS_DOWN')}
-						class="p-3 rounded-lg transition-all border-2"
-						class:bg-red-500={likeValue === 'THUMBS_DOWN'}
-						class:text-white={likeValue === 'THUMBS_DOWN'}
-						class:border-red-500={likeValue === 'THUMBS_DOWN'}
-						class:bg-muted={likeValue !== 'THUMBS_DOWN'}
-						class:text-muted-foreground={likeValue !== 'THUMBS_DOWN'}
-						class:border-transparent={likeValue !== 'THUMBS_DOWN'}
-						aria-label="Thumbs down"
-						aria-pressed={likeValue === 'THUMBS_DOWN'}
-					>
-						<ThumbsDownIcon class="size-6" strokeWidth={2} />
-					</button>
-				</div>
-			</div>
-
-			<!-- TODO: Re-enable Add More / Claim creation in a future phase -->
-			<!-- <div class="flex justify-center pt-1">
+		{/if}
+		<div class="flex items-center justify-center gap-2">
+			<h2 class="text-lg font-semibold text-center tracking-tight">
+				{isEditMode ? 'Edit perspective' : 'Add perspective'}
+			</h2>
+			<div class="relative group">
 				<button
 					type="button"
-					onclick={() => (showMore = !showMore)}
-					class="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium hover:opacity-80 transition-all border border-border text-primary"
+					class="p-1 rounded-full text-muted-foreground hover:opacity-70 transition-opacity"
+					aria-label="About perspectives"
 				>
-					<PlusIcon class="size-4" />
-					Add More...
+					<InfoIcon class="size-4" />
 				</button>
-			</div>
-
-			{#if showMore}
-				<div class="rounded-lg border border-border bg-muted/30 p-4 space-y-3 animate-in fade-in-0 slide-in-from-top-2">
-					<label for="claim-text" class="text-sm font-semibold text-foreground">Add a Claim</label>
-					<textarea
-						id="claim-text"
-						bind:value={claimText}
-						placeholder="e.g., @this ran 22.3 mph in the 1987 game"
-						rows={2}
-						disabled={isClaimPending}
-						class="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-					></textarea>
-					<p class="text-xs text-muted-foreground">
-						Use <code class="font-mono bg-muted px-1 rounded">@this</code> to reference the current content
-					</p>
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						onclick={handleCreateClaim}
-						disabled={isClaimPending || !claimText.trim()}
-						class="w-full"
-					>
-						{isClaimPending ? 'Creating...' : 'Create Claim'}
-					</Button>
-				</div>
-			{/if} -->
-
-			<!-- Action buttons -->
-			<div class="flex items-center justify-center gap-3 pt-1">
-				<Button
-					type="button"
-					variant="outline"
-					size="default"
-					onclick={handleCancel}
-					disabled={isPending}
-					class="px-6"
+				<div
+					class="absolute left-1/2 -translate-x-1/2 top-full mt-2 px-3 py-2 rounded-lg shadow-xl text-xs w-56 text-center z-[100] bg-foreground text-background opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity"
 				>
-					Cancel
-				</Button>
-				<Button type="submit" size="default" disabled={isPending} class="px-6">
-					{#if isPending}
-						{isEditMode ? 'Saving...' : 'Adding...'}
-					{:else}
-						{isEditMode ? 'Save Changes' : 'Add Perspective'}
-					{/if}
-				</Button>
+					Add as much or as little as you like
+					<div class="absolute left-1/2 -translate-x-1/2 -top-1 w-2 h-2 rotate-45 bg-foreground"></div>
+				</div>
 			</div>
-		</form>
-	</DialogContent>
-</Dialog>
+		</div>
+		<p class="text-[13px] font-serif text-muted-foreground text-center mt-0.5 line-clamp-1 max-w-full">
+			{contentName}
+		</p>
+	</div>
+
+	<!-- Overall + Comment row -->
+	<div class="flex items-center gap-3.5 px-5 py-3.5 border-b border-border">
+		<div class="flex flex-col items-center gap-1.5 flex-shrink-0">
+			<span class="font-sans text-[11px] font-medium text-muted-foreground uppercase tracking-[0.06em]"> Overall </span>
+			<Thumbs
+				value={likeValue}
+				onChange={(val) => {
+					likeValue = val;
+				}}
+				size="md"
+			/>
+		</div>
+
+		{#if mobile}
+			<button
+				type="button"
+				onclick={() => {
+					commentFullscreenOpen = true;
+				}}
+				aria-label="Add comment"
+				class="flex flex-1 items-center justify-between gap-2 h-14 px-3 rounded-lg border border-border bg-white cursor-pointer text-left"
+			>
+				<span
+					class="font-serif text-[13px] line-clamp-2 flex-1"
+					class:text-foreground={hasComment}
+					class:text-muted-foreground={!hasComment}
+				>
+					{#if hasComment}
+						{comment.replace(/<[^>]*>/g, '')}
+					{:else}
+						Add a comment
+					{/if}
+				</span>
+				<span class="text-muted-foreground flex-shrink-0">
+					<ExternalLinkIcon class="size-4" />
+				</span>
+			</button>
+		{:else}
+			<div class="flex-1 min-w-0 relative">
+				<CommentEditor
+					value={comment}
+					onChange={handleCommentChange}
+					minHeight={68}
+					showPopout={true}
+					onPopout={() => {
+						commentFullscreenOpen = true;
+					}}
+				/>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Scrollable body — ratings + add field -->
+	<form onsubmit={handleSubmit} class="flex flex-col flex-1 overflow-hidden">
+		<div class="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-3.5">
+			<div class="grid grid-cols-2 gap-3">
+				{#each activeFields as fieldKey, idx (fieldKey)}
+					{@const isLeftCol = idx % 2 === 0}
+					<div class="relative">
+						{#if fieldKey === 'quality'}
+							<RatingInput
+								label="Quality"
+								name="quality"
+								bind:value={quality}
+								compact
+								trackWidth={110}
+								onRemove={() => removeField('quality')}
+							/>
+						{:else if fieldKey === 'agreement'}
+							<RatingInput
+								label="Agreement"
+								name="agreement"
+								bind:value={agreement}
+								compact
+								trackWidth={110}
+								onRemove={() => removeField('agreement')}
+							/>
+						{:else if fieldKey === 'importance'}
+							<RatingInput
+								label="Importance"
+								name="importance"
+								bind:value={importance}
+								compact
+								trackWidth={110}
+								onRemove={() => removeField('importance')}
+							/>
+						{:else if fieldKey === 'confidence'}
+							<RatingInput
+								label="Confidence"
+								name="confidence"
+								bind:value={confidence}
+								compact
+								trackWidth={110}
+								onRemove={() => removeField('confidence')}
+							/>
+						{:else}
+							<RatingInput
+								label={getFieldLabel(fieldKey)}
+								name={fieldKey}
+								value={dynamicValues[fieldKey] ?? null}
+								compact
+								trackWidth={110}
+								onRemove={() => removeField(fieldKey)}
+							/>
+						{/if}
+						<button
+							type="button"
+							onclick={() => removeField(fieldKey)}
+							class="absolute top-1/2 -translate-y-1/2 flex items-center justify-center bg-white border border-border rounded-full shadow-sm text-muted-foreground hover:opacity-70 transition-opacity z-10"
+							style="width: 16px; height: 16px; {isLeftCol
+								? `right: ${mobile ? '4px' : '12px'};`
+								: `left: ${mobile ? '4px' : '12px'};`}"
+							aria-label="Remove {getFieldLabel(fieldKey)}"
+							title="Remove {getFieldLabel(fieldKey)}"
+						>
+							<XIcon class="size-2" strokeWidth={3} />
+						</button>
+					</div>
+				{/each}
+			</div>
+
+			<AddFieldSearch addedKeys={activeFields} onAdd={addField} placeholder="Add a field — e.g. clarity" dense />
+		</div>
+
+		<!-- Action buttons — extra bottom padding on mobile for home indicator -->
+		<div
+			class="flex gap-2.5 px-5 border-t border-border bg-background"
+			style="padding-top: 14px; padding-bottom: {mobile ? 'calc(22px + env(safe-area-inset-bottom))' : '14px'};"
+		>
+			<Button
+				type="button"
+				variant="outline"
+				size="default"
+				onclick={() => onClose()}
+				disabled={isPending}
+				class="flex-1"
+			>
+				Cancel
+			</Button>
+			<Button type="submit" size="default" disabled={isPending} class="flex-1">
+				{#if isPending}
+					{isEditMode ? 'Saving...' : 'Adding...'}
+				{:else}
+					Save perspective
+				{/if}
+			</Button>
+		</div>
+	</form>
+{/snippet}
+
+<!-- Desktop: centered dialog -->
+{#if !isMobile.current}
+	<Dialog
+		bind:open
+		onOpenChange={(isOpen) => {
+			if (!isOpen) onClose();
+		}}
+	>
+		<DialogContent
+			class="sm:max-w-[460px] w-[calc(100vw-2rem)] max-h-[90vh] overflow-hidden p-0 flex flex-col"
+			overlayClass="bg-black/45"
+		>
+			{@render modalBody(false)}
+		</DialogContent>
+	</Dialog>
+{:else}
+	<!-- Mobile: bottom sheet drawer -->
+	<Drawer
+		bind:open
+		onOpenChange={(isOpen) => {
+			if (!isOpen) onClose();
+		}}
+	>
+		<DrawerContent class="max-h-[88vh] flex flex-col p-0">
+			{@render modalBody(true)}
+		</DrawerContent>
+	</Drawer>
+{/if}
+
+{#if commentFullscreenOpen}
+	<CommentFullscreen
+		value={comment}
+		onChange={handleCommentChange}
+		onClose={() => {
+			commentFullscreenOpen = false;
+		}}
+	/>
+{/if}

--- a/frontend/src/lib/components/RatingInput.svelte
+++ b/frontend/src/lib/components/RatingInput.svelte
@@ -14,10 +14,16 @@
 		label,
 		value = $bindable<number | null>(null),
 		name,
+		compact = false,
+		onRemove,
+		trackWidth,
 	}: {
 		label: string;
 		value: number | null;
 		name: string;
+		compact?: boolean;
+		onRemove?: () => void;
+		trackWidth?: number;
 	} = $props();
 
 	// Track whether the user has interacted with this input
@@ -85,7 +91,9 @@
 			clearInterval(intervalId);
 			intervalId = null;
 		}
-		setTimeout(() => { isTouching = false; }, 400);
+		setTimeout(() => {
+			isTouching = false;
+		}, 400);
 	}
 
 	function handleInputChange(e: Event) {
@@ -129,13 +137,11 @@
 
 	// Number display color
 	const numberColor = $derived(
-		hasInteracted
-			? 'var(--color-primary)'
-			: 'color-mix(in srgb, var(--color-muted-foreground) 35%, transparent)',
+		hasInteracted ? 'var(--color-primary)' : 'color-mix(in srgb, var(--color-muted-foreground) 35%, transparent)',
 	);
 </script>
 
-<div class="flex flex-col items-center space-y-1.5">
+<div class="flex flex-col items-center" class:space-y-1.5={!compact} class:space-y-1={compact}>
 	<!-- Label -->
 	<label for={name} class="text-xs font-medium text-center text-muted-foreground">
 		{label}
@@ -187,8 +193,8 @@
 			<ChevronUpIcon class="size-3.5" strokeWidth={2} />
 		</button>
 
-		<!-- Clear button (X) — shown only when hasInteracted -->
-		{#if hasInteracted}
+		<!-- Clear button (X) — shown only when hasInteracted and no onRemove handler -->
+		{#if !onRemove && hasInteracted}
 			<button
 				type="button"
 				onclick={clearRating}
@@ -206,7 +212,7 @@
 	<div
 		onclick={handleProgressBarClick}
 		class="h-1 rounded-full overflow-hidden mx-auto cursor-pointer"
-		style="background-color: var(--color-muted); width: 90px;"
+		style="background-color: var(--color-muted); width: {trackWidth ?? 90}px;"
 		role="presentation"
 	>
 		<div

--- a/frontend/src/lib/components/SafeHtml.svelte
+++ b/frontend/src/lib/components/SafeHtml.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { sanitizeHtml } from '$lib/utils/sanitize';
+
+	/**
+	 * SafeHtml — renders user-generated HTML (e.g., Tiptap review content)
+	 * after sanitizing with DOMPurify. Use this instead of raw {@html}.
+	 */
+	let {
+		html,
+		class: className = '',
+	}: {
+		html: string;
+		class?: string;
+	} = $props();
+
+	const clean = $derived(sanitizeHtml(html));
+</script>
+
+<div class="safe-html {className}">
+	{@html clean}
+</div>
+
+<style>
+	.safe-html :global(ul),
+	.safe-html :global(ol) {
+		padding-left: 22px;
+		margin: 4px 0;
+	}
+	.safe-html :global(li) {
+		margin: 2px 0;
+	}
+	.safe-html :global(p) {
+		margin: 0 0 4px;
+	}
+	.safe-html :global(p:last-child) {
+		margin-bottom: 0;
+	}
+</style>

--- a/frontend/src/lib/components/Thumbs.svelte
+++ b/frontend/src/lib/components/Thumbs.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	/**
+	 * Thumbs — outlined thumbs up/down toggle.
+	 * Down on the left, up on the right. Outlined SVGs that fill on selection.
+	 * Green fill for up, red fill for down.
+	 */
+	type LikeValue = 'THUMBS_UP' | 'THUMBS_DOWN' | null;
+
+	let {
+		value,
+		onChange,
+		size = 'md',
+	}: {
+		value: LikeValue;
+		onChange: (val: LikeValue) => void;
+		size?: 'md' | 'lg';
+	} = $props();
+
+	const dim = $derived(size === 'lg' ? 28 : 22);
+	const gap = $derived(size === 'lg' ? 'gap-3.5' : 'gap-2.5');
+	const isUp = $derived(value === 'THUMBS_UP');
+	const isDown = $derived(value === 'THUMBS_DOWN');
+</script>
+
+<div class="flex items-center justify-center {gap}">
+	<!-- Thumbs down (left) -->
+	<button
+		type="button"
+		onclick={() => onChange(isDown ? null : 'THUMBS_DOWN')}
+		aria-pressed={isDown}
+		aria-label="Thumbs down"
+		class="flex items-center justify-center p-1.5 rounded-lg border-none bg-transparent cursor-pointer transition-transform duration-[120ms] ease-out"
+		style="transform: {isDown ? 'scale(1.05)' : 'scale(1)'};"
+	>
+		<svg
+			width={dim}
+			height={dim}
+			viewBox="0 0 24 24"
+			fill={isDown ? '#b91c1c' : 'none'}
+			stroke={isDown ? '#b91c1c' : 'var(--color-muted-foreground)'}
+			stroke-width={isDown ? 1.6 : 2}
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path d="M17 14V2" />
+			<path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H17v12l-4.34 9.66a1 1 0 0 1-1.66-.43z" />
+		</svg>
+	</button>
+
+	<!-- Thumbs up (right) -->
+	<button
+		type="button"
+		onclick={() => onChange(isUp ? null : 'THUMBS_UP')}
+		aria-pressed={isUp}
+		aria-label="Thumbs up"
+		class="flex items-center justify-center p-1.5 rounded-lg border-none bg-transparent cursor-pointer transition-transform duration-[120ms] ease-out"
+		style="transform: {isUp ? 'scale(1.05)' : 'scale(1)'};"
+	>
+		<svg
+			width={dim}
+			height={dim}
+			viewBox="0 0 24 24"
+			fill={isUp ? '#15803d' : 'none'}
+			stroke={isUp ? '#15803d' : 'var(--color-muted-foreground)'}
+			stroke-width={isUp ? 1.6 : 2}
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path d="M7 10v12" />
+			<path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l4.34-9.66a1 1 0 0 1 1.66.43z" />
+		</svg>
+	</button>
+</div>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-close.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+
+	let { ref = $bindable(null), ...restProps }: DrawerPrimitive.CloseProps = $props();
+</script>
+
+<DrawerPrimitive.Close bind:ref data-slot="drawer-close" {...restProps} />

--- a/frontend/src/lib/components/shadcn/drawer/drawer-content.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-content.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+	import DrawerPortal from "./drawer-portal.svelte";
+	import DrawerOverlay from "./drawer-overlay.svelte";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		portalProps,
+		children,
+		...restProps
+	}: DrawerPrimitive.ContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DrawerPortal>>;
+	} = $props();
+</script>
+
+<DrawerPortal {...portalProps}>
+	<DrawerOverlay />
+	<DrawerPrimitive.Content
+		bind:ref
+		data-slot="drawer-content"
+		class={cn("bg-popover text-popover-foreground flex h-auto flex-col text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm group/drawer-content fixed z-50", className)}
+		{...restProps}
+	>
+		<div
+			class="bg-muted mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block bg-muted mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
+		></div>
+		{@render children?.()}
+	</DrawerPrimitive.Content>
+</DrawerPortal>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-description.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DrawerPrimitive.DescriptionProps = $props();
+</script>
+
+<DrawerPrimitive.Description
+	bind:ref
+	data-slot="drawer-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-footer.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="drawer-footer"
+	class={cn("gap-2 p-4 mt-auto flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-header.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="drawer-header"
+	class={cn("gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-nested.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-nested.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+
+	let {
+		shouldScaleBackground = true,
+		open = $bindable(false),
+		activeSnapPoint = $bindable(null),
+		...restProps
+	}: DrawerPrimitive.RootProps = $props();
+</script>
+
+<DrawerPrimitive.NestedRoot {shouldScaleBackground} bind:open bind:activeSnapPoint {...restProps} />

--- a/frontend/src/lib/components/shadcn/drawer/drawer-overlay.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DrawerPrimitive.OverlayProps = $props();
+</script>
+
+<DrawerPrimitive.Overlay
+	bind:ref
+	data-slot="drawer-overlay"
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-portal.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+
+	let { ...restProps }: DrawerPrimitive.PortalProps = $props();
+</script>
+
+<DrawerPrimitive.Portal {...restProps} />

--- a/frontend/src/lib/components/shadcn/drawer/drawer-title.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DrawerPrimitive.TitleProps = $props();
+</script>
+
+<DrawerPrimitive.Title
+	bind:ref
+	data-slot="drawer-title"
+	class={cn("text-foreground text-base font-medium", className)}
+	{...restProps}
+/>

--- a/frontend/src/lib/components/shadcn/drawer/drawer-trigger.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+
+	let { ref = $bindable(null), ...restProps }: DrawerPrimitive.TriggerProps = $props();
+</script>
+
+<DrawerPrimitive.Trigger bind:ref data-slot="drawer-trigger" {...restProps} />

--- a/frontend/src/lib/components/shadcn/drawer/drawer.svelte
+++ b/frontend/src/lib/components/shadcn/drawer/drawer.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from "vaul-svelte";
+
+	let {
+		shouldScaleBackground = true,
+		open = $bindable(false),
+		activeSnapPoint = $bindable(null),
+		...restProps
+	}: DrawerPrimitive.RootProps = $props();
+</script>
+
+<DrawerPrimitive.Root {shouldScaleBackground} bind:open bind:activeSnapPoint {...restProps} />

--- a/frontend/src/lib/components/shadcn/drawer/index.ts
+++ b/frontend/src/lib/components/shadcn/drawer/index.ts
@@ -1,0 +1,38 @@
+import Root from "./drawer.svelte";
+import Content from "./drawer-content.svelte";
+import Description from "./drawer-description.svelte";
+import Overlay from "./drawer-overlay.svelte";
+import Footer from "./drawer-footer.svelte";
+import Header from "./drawer-header.svelte";
+import Title from "./drawer-title.svelte";
+import NestedRoot from "./drawer-nested.svelte";
+import Close from "./drawer-close.svelte";
+import Trigger from "./drawer-trigger.svelte";
+import Portal from "./drawer-portal.svelte";
+
+export {
+	Root,
+	NestedRoot,
+	Content,
+	Description,
+	Overlay,
+	Footer,
+	Header,
+	Title,
+	Trigger,
+	Portal,
+	Close,
+
+	//
+	Root as Drawer,
+	NestedRoot as DrawerNestedRoot,
+	Content as DrawerContent,
+	Description as DrawerDescription,
+	Overlay as DrawerOverlay,
+	Footer as DrawerFooter,
+	Header as DrawerHeader,
+	Title as DrawerTitle,
+	Trigger as DrawerTrigger,
+	Portal as DrawerPortal,
+	Close as DrawerClose,
+};

--- a/frontend/src/lib/components/shadcn/index.ts
+++ b/frontend/src/lib/components/shadcn/index.ts
@@ -1,6 +1,18 @@
 // Single barrel file for all shadcn components — keep alphabetized
 export { Button, buttonVariants, type ButtonProps, type ButtonSize, type ButtonVariant } from './button/index.js';
 export {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerOverlay,
+	DrawerPortal,
+	DrawerTitle,
+	DrawerTrigger,
+} from './drawer/index.js';
+export {
 	Dialog,
 	DialogClose,
 	DialogContent,

--- a/frontend/src/lib/queries/hooks/useCreatePerspective.ts
+++ b/frontend/src/lib/queries/hooks/useCreatePerspective.ts
@@ -13,6 +13,7 @@ export interface CreatePerspectiveInput {
 	confidence?: number;
 	like?: string;
 	review?: string;
+	customFields?: Record<string, number>;
 }
 
 export function useCreatePerspective() {

--- a/frontend/src/lib/queries/hooks/useUpdatePerspective.ts
+++ b/frontend/src/lib/queries/hooks/useUpdatePerspective.ts
@@ -12,6 +12,7 @@ export interface UpdatePerspectiveInput {
 	confidence?: number;
 	like?: string;
 	review?: string;
+	customFields?: Record<string, number>;
 }
 
 export function useUpdatePerspective() {

--- a/frontend/src/lib/utils/sanitize.ts
+++ b/frontend/src/lib/utils/sanitize.ts
@@ -1,0 +1,25 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * Sanitize HTML from user-generated rich text (Tiptap review/comment content).
+ * Allows safe formatting tags only — strips scripts, event handlers, and dangerous attributes.
+ */
+export function sanitizeHtml(dirty: string): string {
+	return DOMPurify.sanitize(dirty, {
+		ALLOWED_TAGS: [
+			'p',
+			'br',
+			'strong',
+			'b',
+			'em',
+			'i',
+			'u',
+			'ul',
+			'ol',
+			'li',
+			'a',
+			'span',
+		],
+		ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
+	});
+}

--- a/frontend/tests/components/PerspectivePopover.test.ts
+++ b/frontend/tests/components/PerspectivePopover.test.ts
@@ -60,15 +60,13 @@ describe('PerspectivePopover component', () => {
 			expect(container).toBeTruthy();
 		});
 
-		it('renders dialog with "Add Perspective" title when creating', async () => {
+		it('renders dialog with "Add perspective" title when creating', async () => {
 			renderPopover({ existingPerspective: null });
 			await tick();
-			// Both the dialog title and submit button contain "Add Perspective"
-			const matches = screen.getAllByText('Add Perspective');
-			expect(matches.length).toBeGreaterThanOrEqual(1);
+			expect(screen.getByText('Add perspective')).toBeInTheDocument();
 		});
 
-		it('renders dialog with "Edit Perspective" title when editing', async () => {
+		it('renders dialog with "Edit perspective" title when editing', async () => {
 			renderPopover({
 				existingPerspective: {
 					id: '1',
@@ -80,7 +78,7 @@ describe('PerspectivePopover component', () => {
 				},
 			});
 			await tick();
-			expect(screen.getByText('Edit Perspective')).toBeInTheDocument();
+			expect(screen.getByText('Edit perspective')).toBeInTheDocument();
 		});
 	});
 
@@ -157,10 +155,10 @@ describe('PerspectivePopover component', () => {
 			expect(screen.getByLabelText('Thumbs down')).toBeInTheDocument();
 		});
 
-		it('renders like section label', async () => {
+		it('renders overall section label', async () => {
 			renderPopover();
 			await tick();
-			expect(screen.getByText('Like')).toBeInTheDocument();
+			expect(screen.getByText('Overall')).toBeInTheDocument();
 		});
 
 		it('thumbs up button has aria-pressed attribute', async () => {
@@ -189,14 +187,14 @@ describe('PerspectivePopover component', () => {
 			expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
 		});
 
-		it('renders "Add Perspective" button when creating', async () => {
+		it('renders "Save perspective" button when creating', async () => {
 			renderPopover({ existingPerspective: null });
 			await tick();
-			const submitBtn = screen.getByRole('button', { name: 'Add Perspective' });
+			const submitBtn = screen.getByRole('button', { name: 'Save perspective' });
 			expect(submitBtn).toBeInTheDocument();
 		});
 
-		it('renders "Save Changes" button when editing', async () => {
+		it('renders "Save perspective" button when editing', async () => {
 			renderPopover({
 				existingPerspective: {
 					id: '1',
@@ -208,7 +206,7 @@ describe('PerspectivePopover component', () => {
 				},
 			});
 			await tick();
-			const submitBtn = screen.getByRole('button', { name: 'Save Changes' });
+			const submitBtn = screen.getByRole('button', { name: 'Save perspective' });
 			expect(submitBtn).toBeInTheDocument();
 		});
 	});
@@ -233,8 +231,7 @@ describe('PerspectivePopover component', () => {
 		it('displays dialog title', async () => {
 			renderPopover({ existingPerspective: null });
 			await tick();
-			const matches = screen.getAllByText('Add Perspective');
-			expect(matches.length).toBeGreaterThanOrEqual(1);
+			expect(screen.getByText('Add perspective')).toBeInTheDocument();
 		});
 
 		it('dialog has header with content name', async () => {
@@ -248,8 +245,8 @@ describe('PerspectivePopover component', () => {
 		it('is in create mode when existingPerspective is null', async () => {
 			renderPopover({ existingPerspective: null });
 			await tick();
-			const matches = screen.getAllByText('Add Perspective');
-			expect(matches.length).toBeGreaterThanOrEqual(2); // title + button
+			expect(screen.getByText('Add perspective')).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Save perspective' })).toBeInTheDocument();
 		});
 
 		it('is in edit mode when existingPerspective is provided', async () => {
@@ -264,8 +261,8 @@ describe('PerspectivePopover component', () => {
 				},
 			});
 			await tick();
-			expect(screen.getByText('Edit Perspective')).toBeInTheDocument();
-			expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument();
+			expect(screen.getByText('Edit perspective')).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Save perspective' })).toBeInTheDocument();
 		});
 
 		it('populates like value from existingPerspective', async () => {
@@ -388,7 +385,7 @@ describe('PerspectivePopover component', () => {
 			// Click thumbs up to set at least one field
 			await fireEvent.click(screen.getByLabelText('Thumbs up'));
 			// Submit
-			const submitBtn = screen.getByRole('button', { name: 'Add Perspective' });
+			const submitBtn = screen.getByRole('button', { name: 'Save perspective' });
 			await fireEvent.click(submitBtn);
 			expect(mocks.mockCreateMutate).toHaveBeenCalled();
 		});
@@ -405,7 +402,7 @@ describe('PerspectivePopover component', () => {
 				},
 			});
 			await tick();
-			const submitBtn = screen.getByRole('button', { name: 'Save Changes' });
+			const submitBtn = screen.getByRole('button', { name: 'Save perspective' });
 			await fireEvent.click(submitBtn);
 			expect(mocks.mockUpdateMutate).toHaveBeenCalled();
 		});
@@ -430,7 +427,7 @@ describe('PerspectivePopover component', () => {
 			renderPopover({ existingPerspective: null });
 			await tick();
 			expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-			expect(screen.getByRole('button', { name: 'Add Perspective' })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Save perspective' })).toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Redesign the perspective input modal based on design handoff (Variation A)
- Add rich text comment editor (Tiptap), dynamic rating fields with add/remove, outlined thumbs up/down
- Mobile renders as bottom sheet drawer (Vaul/shadcn Drawer), desktop as centered dialog

## Problem
The existing perspective modal had a static layout with fixed rating fields, no comment support, and used the same centered dialog on all screen sizes. The design called for a richer, more flexible input format.

## Solution

### New Components
- **CommentEditor** — Tiptap-based rich text with B/I/U + bullet/numbered list toolbar
- **CommentFullscreen** — Expanded overlay for longer comments
- **Thumbs** — Outlined SVG thumbs (down-left, up-right) that fill on selection
- **AddFieldSearch** — Searchable dropdown to add/remove rating dimensions with custom field creation

### Layout Changes
- Header with title + info tooltip + content name (single line truncated)
- Overall (thumbs) + Comment row directly under header
- Scrollable 2x2 rating grid with gutter-positioned remove buttons
- Equal-width Cancel / Save perspective buttons
- Mobile: bottom sheet drawer with grabber handle and safe-area padding
- Desktop: centered dialog (460px max-width)

### Infrastructure
- Added shadcn Drawer component (Vaul Svelte)
- Fixed `components.json` missing `ui` alias (prevented wrong install path)
- Documented shadcn install gotcha in `frontend/CLAUDE.md`

## Technical Changes
- `PerspectivePopover.svelte` — Full redesign using `{#snippet}` for shared content between Dialog/Drawer
- `RatingInput.svelte` — Added `compact`, `onRemove`, `trackWidth` props
- `shadcn/index.ts` — Added Drawer exports
- `PerspectivePopover.test.ts` — Updated for new UI text

## Backend Integration TODOs
- [ ] Add `comment` field to perspective GraphQL schema + DB column
- [ ] Schema support for dynamic rating fields beyond core 4
- [ ] API for custom field definitions (persist/load)
- [ ] Available fields catalog endpoint (currently hardcoded)
- [ ] Include comment in create/update mutation payloads

## Testing
- [x] `pnpm run check` — zero new type errors
- [x] `pnpm run test:run` — 697 tests pass (33 files)
- [x] Chrome DevTools visual verification at desktop (1280px) and mobile (375px)
- [x] Console: no new errors
- [ ] Manual: test add/remove fields, thumbs toggle, comment editor, fullscreen comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)